### PR TITLE
Add pinned tab for todo list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,17 +3,28 @@ import { observer } from 'mobx-react-lite'
 import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
+import { PinnedItem } from './components/PinnedItem'
+import { PinnedDropZone } from './components/PinnedDropZone'
 import { useTodoStore } from './stores/TodoStoreContext'
 
 const AppComponent = () => {
   const store = useTodoStore()
   const [newTitle, setNewTitle] = useState('')
+  const [activeTab, setActiveTab] = useState<'pinned' | 'todos'>('pinned')
+  const pinnedTodos = store.pinnedTodos
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
     store.addTodo(null, newTitle)
     setNewTitle('')
   }
+
+  const sectionClassName = [
+    'flex-1 rounded-3xl bg-white/60 p-5 shadow-inner ring-1 ring-white/40',
+    activeTab === 'pinned' ? 'mt-6' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
 
   return (
     <div className="min-h-screen bg-canvas-light text-slate-900">
@@ -26,41 +37,92 @@ const AppComponent = () => {
           </p>
         </header>
 
-        <form
-          onSubmit={handleSubmit}
-          className="mb-8 flex flex-col gap-3 rounded-2xl bg-white/80 p-4 shadow-sm ring-1 ring-slate-200 sm:flex-row sm:items-center"
-        >
-          <input
-            className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
-            placeholder="Новая задача"
-            value={newTitle}
-            onChange={(event) => setNewTitle(event.target.value)}
-          />
+        <div className="mb-6 inline-flex rounded-2xl bg-white/80 p-1 text-sm font-medium text-slate-500 shadow-sm ring-1 ring-slate-200">
           <button
-            type="submit"
-            className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 sm:w-auto"
-            aria-label="Добавить задачу"
+            type="button"
+            onClick={() => setActiveTab('pinned')}
+            className={[
+              'rounded-xl px-4 py-2 transition',
+              activeTab === 'pinned'
+                ? 'bg-slate-900 text-white shadow'
+                : 'text-slate-600 hover:text-slate-800',
+            ].join(' ')}
+            aria-pressed={activeTab === 'pinned'}
           >
-            <FiPlus />
-            Добавить
+            Закрепленные
           </button>
-        </form>
+          <button
+            type="button"
+            onClick={() => setActiveTab('todos')}
+            className={[
+              'rounded-xl px-4 py-2 transition',
+              activeTab === 'todos'
+                ? 'bg-slate-900 text-white shadow'
+                : 'text-slate-600 hover:text-slate-800',
+            ].join(' ')}
+            aria-pressed={activeTab === 'todos'}
+          >
+            Список задач
+          </button>
+        </div>
 
-        <section className="flex-1 rounded-3xl bg-white/60 p-5 shadow-inner ring-1 ring-white/40">
-          <div className="space-y-3">
-            <DropZone parentId={null} depth={0} index={0} />
-            {store.todos.map((todo, index) => (
-              <Fragment key={todo.id}>
-                <TodoItem todo={todo} depth={0} />
-                <DropZone parentId={null} depth={0} index={index + 1} />
-              </Fragment>
-            ))}
-          </div>
+        {activeTab === 'todos' && (
+          <form
+            onSubmit={handleSubmit}
+            className="mb-8 flex flex-col gap-3 rounded-2xl bg-white/80 p-4 shadow-sm ring-1 ring-slate-200 sm:flex-row sm:items-center"
+          >
+            <input
+              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+              placeholder="Новая задача"
+              value={newTitle}
+              onChange={(event) => setNewTitle(event.target.value)}
+            />
+            <button
+              type="submit"
+              className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 sm:w-auto"
+              aria-label="Добавить задачу"
+            >
+              <FiPlus />
+              Добавить
+            </button>
+          </form>
+        )}
 
-          {store.todos.length === 0 && (
-            <div className="mt-6 rounded-2xl border border-dashed border-slate-300/80 bg-white/70 px-6 py-10 text-center text-sm text-slate-500">
-              Начните с новой задачи — вы всегда сможете добавить вложенные подзадачи и перетащить элементы между уровнями.
-            </div>
+        <section className={sectionClassName}>
+          {activeTab === 'pinned' ? (
+            pinnedTodos.length > 0 ? (
+              <div className="space-y-3">
+                <PinnedDropZone index={0} />
+                {pinnedTodos.map((todo, index) => (
+                  <Fragment key={todo.id}>
+                    <PinnedItem todo={todo} />
+                    <PinnedDropZone index={index + 1} />
+                  </Fragment>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-2 rounded-2xl border border-dashed border-amber-200 bg-white/70 px-6 py-10 text-center text-sm text-slate-500">
+                Закрепите задачи на вкладке «Список задач», чтобы увидеть их здесь.
+              </div>
+            )
+          ) : (
+            <>
+              <div className="space-y-3">
+                <DropZone parentId={null} depth={0} index={0} />
+                {store.todos.map((todo, index) => (
+                  <Fragment key={todo.id}>
+                    <TodoItem todo={todo} depth={0} />
+                    <DropZone parentId={null} depth={0} index={index + 1} />
+                  </Fragment>
+                ))}
+              </div>
+
+              {store.todos.length === 0 && (
+                <div className="mt-6 rounded-2xl border border-dashed border-slate-300/80 bg-white/70 px-6 py-10 text-center text-sm text-slate-500">
+                  Начните с новой задачи — вы всегда сможете добавить вложенные подзадачи и перетащить элементы между уровнями.
+                </div>
+              )}
+            </>
           )}
         </section>
       </div>

--- a/src/components/PinnedDropZone.tsx
+++ b/src/components/PinnedDropZone.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { useTodoStore } from '../stores/TodoStoreContext'
+
+interface PinnedDropZoneProps {
+  index: number
+}
+
+const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
+  const store = useTodoStore()
+  const [isOver, setIsOver] = useState(false)
+
+  const draggedId = store.draggedPinnedId
+  const canAccept = draggedId !== null
+  const showPlaceholder = draggedId !== null
+
+  const handleDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    if (!isOver) {
+      setIsOver(true)
+    }
+  }
+
+  const handleDragLeave: React.DragEventHandler<HTMLDivElement> = () => {
+    if (isOver) {
+      setIsOver(false)
+    }
+  }
+
+  const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept || draggedId === null) return
+    event.preventDefault()
+    setIsOver(false)
+    store.movePinnedTodo(draggedId, index)
+  }
+
+  const heightClass = showPlaceholder ? 'h-2' : 'h-0'
+  const marginClass = showPlaceholder ? 'my-1' : 'my-0'
+
+  return (
+    <div className="py-0">
+      <div
+        className={[
+          'rounded border border-dashed transition-all duration-150 ease-out',
+          heightClass,
+          marginClass,
+          showPlaceholder ? 'opacity-100' : 'opacity-0',
+          canAccept ? 'border-amber-300 bg-amber-200/60' : 'border-transparent bg-transparent',
+          isOver && canAccept ? 'border-amber-400 bg-amber-300/70' : '',
+        ].join(' ')}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        aria-hidden
+      />
+    </div>
+  )
+}
+
+export const PinnedDropZone = observer(PinnedDropZoneComponent)

--- a/src/components/PinnedItem.tsx
+++ b/src/components/PinnedItem.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { FiCheck, FiCheckCircle, FiCircle, FiEdit2, FiStar, FiTrash2, FiX } from 'react-icons/fi'
+import { type TodoNode } from '../stores/TodoStore'
+import { useTodoStore } from '../stores/TodoStoreContext'
+
+interface PinnedItemProps {
+  todo: TodoNode
+}
+
+const actionButtonStyles =
+  'rounded-lg p-1.5 text-slate-400 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none'
+
+const PinnedItemComponent = ({ todo }: PinnedItemProps) => {
+  const store = useTodoStore()
+  const [isEditing, setIsEditing] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(todo.title)
+
+  useEffect(() => {
+    setTitleDraft(todo.title)
+  }, [todo.title])
+
+  const isDragging = store.draggedPinnedId === todo.id
+
+  const handleToggle = () => {
+    store.toggleTodo(todo.id)
+  }
+
+  const handleEditSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    store.updateTitle(todo.id, titleDraft)
+    setIsEditing(false)
+  }
+
+  const handleDelete = () => {
+    store.deleteTodo(todo.id)
+  }
+
+  const handleUnpin = () => {
+    store.unpinTodo(todo.id)
+  }
+
+  const handleDragStart: React.DragEventHandler<HTMLDivElement> = (event) => {
+    store.setPinnedDragged(todo.id)
+    event.dataTransfer.setData('text/plain', todo.id)
+    event.dataTransfer.effectAllowed = 'move'
+  }
+
+  const handleDragEnd: React.DragEventHandler<HTMLDivElement> = () => {
+    store.clearPinnedDragged()
+  }
+
+  const titleStyles = useMemo(
+    () =>
+      [
+        'text-base font-medium leading-snug transition-colors',
+        todo.completed ? 'text-slate-400 line-through' : 'text-slate-700',
+      ].join(' '),
+    [todo.completed],
+  )
+
+  return (
+    <div
+      className={[
+        'group rounded-xl bg-white/95 ring-1 ring-slate-200 transition-all duration-200 hover:shadow-md',
+        isDragging ? 'opacity-60 ring-2 ring-amber-300' : '',
+      ].join(' ')}
+      draggable={!isEditing}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="flex items-center gap-3 px-4 py-3">
+        <button
+          type="button"
+          onClick={handleToggle}
+          className={`${actionButtonStyles} -ml-1.5 text-xl text-slate-500`}
+          aria-label={todo.completed ? 'Отметить как невыполненную' : 'Отметить как выполненную'}
+        >
+          {todo.completed ? <FiCheckCircle /> : <FiCircle />}
+        </button>
+
+        <div className="flex-1">
+          {isEditing ? (
+            <form onSubmit={handleEditSubmit} className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <input
+                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-slate-400 focus:outline-none"
+                autoFocus
+                value={titleDraft}
+                onChange={(event) => setTitleDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    setTitleDraft(todo.title)
+                    setIsEditing(false)
+                  }
+                }}
+                placeholder="Название задачи"
+              />
+              <div className="flex items-center gap-1 self-end sm:self-auto">
+                <button
+                  type="submit"
+                  className={`${actionButtonStyles} bg-emerald-500 text-white hover:bg-emerald-500/90`}
+                  aria-label="Сохранить название"
+                >
+                  <FiCheck />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setTitleDraft(todo.title)
+                    setIsEditing(false)
+                  }}
+                  className={`${actionButtonStyles} hover:bg-slate-200`}
+                  aria-label="Отменить редактирование"
+                >
+                  <FiX />
+                </button>
+              </div>
+            </form>
+          ) : (
+            <p className={titleStyles}>{todo.title}</p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1">
+          {!isEditing && (
+            <>
+              <button
+                type="button"
+                onClick={handleUnpin}
+                className={`${actionButtonStyles} text-amber-500 hover:text-amber-600`}
+                aria-label="Открепить задачу"
+              >
+                <FiStar />
+              </button>
+              <button
+                type="button"
+                onClick={() => setIsEditing(true)}
+                className={actionButtonStyles}
+                aria-label="Редактировать задачу"
+              >
+                <FiEdit2 />
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                className={`${actionButtonStyles} text-rose-400 hover:text-rose-600`}
+                aria-label="Удалить задачу"
+              >
+                <FiTrash2 />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const PinnedItem = observer(PinnedItemComponent)

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -6,6 +6,7 @@ import {
   FiCircle,
   FiEdit2,
   FiPlus,
+  FiStar,
   FiTrash2,
   FiX,
 } from 'react-icons/fi'
@@ -30,6 +31,7 @@ const TodoItemComponent = ({ todo, depth }: TodoItemProps) => {
 
   const canAddChild = depth < MAX_DEPTH
   const isDragging = store.draggedId === todo.id
+  const isPinned = store.isPinned(todo.id)
 
   useEffect(() => {
     setTitleDraft(todo.title)
@@ -141,6 +143,20 @@ const TodoItemComponent = ({ todo, depth }: TodoItemProps) => {
           <div className="flex items-center gap-1">
             {!isEditing && (
               <>
+                <button
+                  type="button"
+                  onClick={() => store.togglePinned(todo.id)}
+                  className={[
+                    actionButtonStyles,
+                    isPinned
+                      ? 'text-amber-500 hover:text-amber-600'
+                      : 'text-slate-400 hover:text-slate-600',
+                  ].join(' ')}
+                  aria-label={isPinned ? 'Открепить задачу' : 'Закрепить задачу'}
+                  aria-pressed={isPinned}
+                >
+                  <FiStar />
+                </button>
                 {canAddChild && (
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- add a default "Закрепленные" tab with tab selector and pinned task layout on the main page
- implement pinned item and drop zone components so the pinned list can be sorted by drag and drop
- extend the todo store and existing item controls with pin/unpin logic that keeps the lists in sync

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca11e487f083308d900dcf0fb1afd0