### PR TITLE
Add pinned tasks tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,17 +3,21 @@ import { observer } from 'mobx-react-lite'
 import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
+import { PinnedDropZone } from './components/PinnedDropZone'
 import { useTodoStore } from './stores/TodoStoreContext'
 
 const AppComponent = () => {
   const store = useTodoStore()
   const [newTitle, setNewTitle] = useState('')
+  const [activeTab, setActiveTab] = useState<'pinned' | 'all'>('pinned')
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
     store.addTodo(null, newTitle)
     setNewTitle('')
   }
+
+  const pinnedTodos = store.pinnedTodos
 
   return (
     <div className="min-h-screen bg-canvas-light text-slate-900">
@@ -47,20 +51,71 @@ const AppComponent = () => {
         </form>
 
         <section className="flex-1 rounded-3xl bg-white/60 p-5 shadow-inner ring-1 ring-white/40">
-          <div className="space-y-3">
-            <DropZone parentId={null} depth={0} index={0} />
-            {store.todos.map((todo, index) => (
-              <Fragment key={todo.id}>
-                <TodoItem todo={todo} depth={0} />
-                <DropZone parentId={null} depth={0} index={index + 1} />
-              </Fragment>
-            ))}
+          <div className="mb-6 flex justify-start">
+            <div className="flex rounded-2xl bg-white/70 p-1 text-sm font-medium text-slate-500 shadow-sm ring-1 ring-slate-200/70">
+              <button
+                type="button"
+                onClick={() => setActiveTab('pinned')}
+                className={[
+                  'rounded-xl px-4 py-2 transition focus-visible:outline-none',
+                  activeTab === 'pinned'
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700',
+                ].join(' ')}
+              >
+                Закрепленные
+              </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab('all')}
+                className={[
+                  'rounded-xl px-4 py-2 transition focus-visible:outline-none',
+                  activeTab === 'all'
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700',
+                ].join(' ')}
+              >
+                Список задач
+              </button>
+            </div>
           </div>
 
-          {store.todos.length === 0 && (
-            <div className="mt-6 rounded-2xl border border-dashed border-slate-300/80 bg-white/70 px-6 py-10 text-center text-sm text-slate-500">
-              Начните с новой задачи — вы всегда сможете добавить вложенные подзадачи и перетащить элементы между уровнями.
-            </div>
+          {activeTab === 'pinned' ? (
+            <>
+              {pinnedTodos.length > 0 ? (
+                <div className="space-y-3">
+                  <PinnedDropZone index={0} />
+                  {pinnedTodos.map((todo, index) => (
+                    <Fragment key={todo.id}>
+                      <TodoItem todo={todo} depth={0} allowChildren={false} />
+                      <PinnedDropZone index={index + 1} />
+                    </Fragment>
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-2xl border border-dashed border-amber-200 bg-white/80 px-6 py-10 text-center text-sm text-slate-500">
+                  Закрепите важные задачи на вкладке «Список задач», чтобы быстро возвращаться к ним.
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              <div className="space-y-3">
+                <DropZone parentId={null} depth={0} index={0} />
+                {store.todos.map((todo, index) => (
+                  <Fragment key={todo.id}>
+                    <TodoItem todo={todo} depth={0} />
+                    <DropZone parentId={null} depth={0} index={index + 1} />
+                  </Fragment>
+                ))}
+              </div>
+
+              {store.todos.length === 0 && (
+                <div className="mt-6 rounded-2xl border border-dashed border-slate-300/80 bg-white/70 px-6 py-10 text-center text-sm text-slate-500">
+                  Начните с новой задачи — вы всегда сможете добавить вложенные подзадачи и перетащить элементы между уровнями.
+                </div>
+              )}
+            </>
           )}
         </section>
       </div>

--- a/src/components/PinnedDropZone.tsx
+++ b/src/components/PinnedDropZone.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { useTodoStore } from '../stores/TodoStoreContext'
+
+interface PinnedDropZoneProps {
+  index: number
+}
+
+const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
+  const store = useTodoStore()
+  const [isOver, setIsOver] = useState(false)
+
+  const draggedId = store.draggedId
+  const canAccept = draggedId !== null && store.isPinned(draggedId)
+  const showPlaceholder = canAccept
+
+  const handleDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    if (!isOver) {
+      setIsOver(true)
+    }
+  }
+
+  const handleDragLeave: React.DragEventHandler<HTMLDivElement> = () => {
+    if (isOver) {
+      setIsOver(false)
+    }
+  }
+
+  const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept || draggedId === null) return
+    event.preventDefault()
+    setIsOver(false)
+    store.movePinnedTodo(draggedId, index)
+    store.clearDragged()
+  }
+
+  const heightClass = showPlaceholder ? 'h-2' : 'h-0'
+  const marginClass = showPlaceholder ? 'my-1' : 'my-0'
+
+  return (
+    <div className="py-0">
+      <div
+        className={[
+          'rounded border border-dashed transition-all duration-150 ease-out',
+          heightClass,
+          marginClass,
+          showPlaceholder ? 'opacity-100' : 'opacity-0',
+          canAccept ? 'border-amber-300 bg-amber-200/40' : 'border-transparent bg-transparent',
+          isOver && canAccept ? 'border-amber-400 bg-amber-200/70' : '',
+        ].join(' ')}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        aria-hidden
+      />
+    </div>
+  )
+}
+
+export const PinnedDropZone = observer(PinnedDropZoneComponent)

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -6,6 +6,7 @@ import {
   FiCircle,
   FiEdit2,
   FiPlus,
+  FiStar,
   FiTrash2,
   FiX,
 } from 'react-icons/fi'
@@ -16,19 +17,20 @@ import { useTodoStore } from '../stores/TodoStoreContext'
 interface TodoItemProps {
   todo: TodoNode
   depth: number
+  allowChildren?: boolean
 }
 
 const actionButtonStyles =
   'rounded-lg p-1.5 text-slate-400 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none'
 
-const TodoItemComponent = ({ todo, depth }: TodoItemProps) => {
+const TodoItemComponent = ({ todo, depth, allowChildren = true }: TodoItemProps) => {
   const store = useTodoStore()
   const [isEditing, setIsEditing] = useState(false)
   const [isAddingChild, setIsAddingChild] = useState(false)
   const [titleDraft, setTitleDraft] = useState(todo.title)
   const [childTitle, setChildTitle] = useState('')
 
-  const canAddChild = depth < MAX_DEPTH
+  const canAddChild = allowChildren && depth < MAX_DEPTH
   const isDragging = store.draggedId === todo.id
 
   useEffect(() => {
@@ -54,6 +56,10 @@ const TodoItemComponent = ({ todo, depth }: TodoItemProps) => {
 
   const handleDelete = () => {
     store.deleteTodo(todo.id)
+  }
+
+  const handleTogglePinned = () => {
+    store.togglePinned(todo.id)
   }
 
   const handleDragStart: React.DragEventHandler<HTMLDivElement> = (event) => {
@@ -141,6 +147,18 @@ const TodoItemComponent = ({ todo, depth }: TodoItemProps) => {
           <div className="flex items-center gap-1">
             {!isEditing && (
               <>
+                <button
+                  type="button"
+                  onClick={handleTogglePinned}
+                  className={[
+                    actionButtonStyles,
+                    todo.pinned ? 'text-amber-500 hover:text-amber-500' : '',
+                  ].join(' ')}
+                  aria-label={todo.pinned ? 'Открепить задачу' : 'Закрепить задачу'}
+                  aria-pressed={todo.pinned}
+                >
+                  <FiStar className={todo.pinned ? 'text-amber-500' : undefined} />
+                </button>
                 {canAddChild && (
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- add a pinned tab to the main layout and show pinned todos with a flat list
- allow users to toggle pinned status on tasks and reorder pinned items via dedicated drop zones
- extend the todo store to track pinned order and clean up pinned entries when tasks are removed

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca11e487f083308d900dcf0fb1afd0