### PR TITLE
Add pinned tasks tab with drag sorting

### DIFF
--- a/src/components/PinnedDropZone.tsx
+++ b/src/components/PinnedDropZone.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { useTodoStore } from '../stores/TodoStoreContext'
+
+interface PinnedDropZoneProps {
+  index: number
+}
+
+const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
+  const store = useTodoStore()
+  const [isOver, setIsOver] = useState(false)
+
+  const draggedId = store.draggedPinnedId
+  const canAccept = draggedId !== null
+  const showPlaceholder = draggedId !== null
+
+  const handleDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    if (!isOver) {
+      setIsOver(true)
+    }
+  }
+
+  const handleDragLeave: React.DragEventHandler<HTMLDivElement> = () => {
+    if (isOver) {
+      setIsOver(false)
+    }
+  }
+
+  const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept || draggedId === null) return
+    event.preventDefault()
+    setIsOver(false)
+    store.movePinnedTodo(draggedId, index)
+  }
+
+  const heightClass = showPlaceholder ? 'h-2' : 'h-0'
+  const marginClass = showPlaceholder ? 'my-1' : 'my-0'
+
+  return (
+    <div className="py-0">
+      <div
+        className={[
+          'rounded border border-dashed transition-all duration-150 ease-out',
+          heightClass,
+          marginClass,
+          showPlaceholder ? 'opacity-100' : 'opacity-0',
+          canAccept ? 'border-slate-300 bg-slate-200/60' : 'border-transparent bg-transparent',
+          isOver && canAccept ? 'border-slate-400 bg-slate-300' : '',
+        ].join(' ')}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        aria-hidden
+      />
+    </div>
+  )
+}
+
+export const PinnedDropZone = observer(PinnedDropZoneComponent)


### PR DESCRIPTION
## Summary
- add a pinned tab to display and reorder starred tasks
- extend the todo store and item component to support pinning and pinned drag state
- create a dedicated pinned drop zone component for handling the flat sortable list

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca11e487f083308d900dcf0fb1afd0