### PR TITLE
Add pinned tasks tab with sortable order

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,17 +3,27 @@ import { observer } from 'mobx-react-lite'
 import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
+import { PinnedDropZone } from './components/PinnedDropZone'
 import { useTodoStore } from './stores/TodoStoreContext'
+
+type TabKey = 'pinned' | 'todos'
 
 const AppComponent = () => {
   const store = useTodoStore()
+  const [activeTab, setActiveTab] = useState<TabKey>('pinned')
   const [newTitle, setNewTitle] = useState('')
+  const pinnedTodos = store.pinnedTodos
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
     store.addTodo(null, newTitle)
     setNewTitle('')
   }
+
+  const tabs: Array<{ id: TabKey; label: string }> = [
+    { id: 'pinned', label: 'Закрепленные' },
+    { id: 'todos', label: 'Список задач' },
+  ]
 
   return (
     <div className="min-h-screen bg-canvas-light text-slate-900">
@@ -22,45 +32,88 @@ const AppComponent = () => {
           <p className="text-sm font-medium uppercase tracking-wide text-slate-400">Задачи</p>
           <h1 className="mt-2 text-3xl font-semibold text-slate-800">Дерево задач</h1>
           <p className="mt-3 max-w-2xl text-sm text-slate-500">
-            Добавляйте задачи, группируйте их по уровням и перетаскивайте элементы, чтобы быстро управлять приоритетами. Максимальная глубина — три уровня.
+            Добавляйте задачи, группируйте их по уровням и перетаскивайте элементы, чтобы быстро управлять приоритетами.
+            Максимальная глубина — три уровня. Закрепляйте важные задачи, чтобы они появлялись на главной вкладке.
           </p>
         </header>
 
-        <form
-          onSubmit={handleSubmit}
-          className="mb-8 flex flex-col gap-3 rounded-2xl bg-white/80 p-4 shadow-sm ring-1 ring-slate-200 sm:flex-row sm:items-center"
-        >
-          <input
-            className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
-            placeholder="Новая задача"
-            value={newTitle}
-            onChange={(event) => setNewTitle(event.target.value)}
-          />
-          <button
-            type="submit"
-            className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 sm:w-auto"
-            aria-label="Добавить задачу"
+        <div className="mb-6 flex flex-wrap gap-2">
+          {tabs.map((tab) => {
+            const isActive = activeTab === tab.id
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => setActiveTab(tab.id)}
+                className={[
+                  'rounded-full px-4 py-2 text-sm font-medium transition',
+                  isActive ? 'bg-slate-900 text-white shadow-sm' : 'bg-white/70 text-slate-600 hover:bg-white/90',
+                ].join(' ')}
+                aria-pressed={isActive}
+              >
+                {tab.label}
+              </button>
+            )
+          })}
+        </div>
+
+        {activeTab === 'todos' && (
+          <form
+            onSubmit={handleSubmit}
+            className="mb-8 flex flex-col gap-3 rounded-2xl bg-white/80 p-4 shadow-sm ring-1 ring-slate-200 sm:flex-row sm:items-center"
           >
-            <FiPlus />
-            Добавить
-          </button>
-        </form>
+            <input
+              className="w-full rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+              placeholder="Новая задача"
+              value={newTitle}
+              onChange={(event) => setNewTitle(event.target.value)}
+            />
+            <button
+              type="submit"
+              className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-3 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 sm:w-auto"
+              aria-label="Добавить задачу"
+            >
+              <FiPlus />
+              Добавить
+            </button>
+          </form>
+        )}
 
         <section className="flex-1 rounded-3xl bg-white/60 p-5 shadow-inner ring-1 ring-white/40">
-          <div className="space-y-3">
-            <DropZone parentId={null} depth={0} index={0} />
-            {store.todos.map((todo, index) => (
-              <Fragment key={todo.id}>
-                <TodoItem todo={todo} depth={0} />
-                <DropZone parentId={null} depth={0} index={index + 1} />
-              </Fragment>
-            ))}
-          </div>
+          {activeTab === 'pinned' ? (
+            pinnedTodos.length > 0 ? (
+              <div className="space-y-3">
+                <PinnedDropZone index={0} />
+                {pinnedTodos.map((todo, index) => (
+                  <Fragment key={todo.id}>
+                    <TodoItem todo={todo} depth={0} allowChildren={false} />
+                    <PinnedDropZone index={index + 1} />
+                  </Fragment>
+                ))}
+              </div>
+            ) : (
+              <div className="mt-6 rounded-2xl border border-dashed border-slate-300/80 bg-white/70 px-6 py-10 text-center text-sm text-slate-500">
+                Закрепите задачи на вкладке «Список задач», чтобы быстро переходить к ним с главного экрана.
+              </div>
+            )
+          ) : (
+            <>
+              <div className="space-y-3">
+                <DropZone parentId={null} depth={0} index={0} />
+                {store.todos.map((todo, index) => (
+                  <Fragment key={todo.id}>
+                    <TodoItem todo={todo} depth={0} />
+                    <DropZone parentId={null} depth={0} index={index + 1} />
+                  </Fragment>
+                ))}
+              </div>
 
-          {store.todos.length === 0 && (
-            <div className="mt-6 rounded-2xl border border-dashed border-slate-300/80 bg-white/70 px-6 py-10 text-center text-sm text-slate-500">
-              Начните с новой задачи — вы всегда сможете добавить вложенные подзадачи и перетащить элементы между уровнями.
-            </div>
+              {store.todos.length === 0 && (
+                <div className="mt-6 rounded-2xl border border-dashed border-slate-300/80 bg-white/70 px-6 py-10 text-center text-sm text-slate-500">
+                  Начните с новой задачи — вы всегда сможете добавить вложенные подзадачи и перетащить элементы между уровнями.
+                </div>
+              )}
+            </>
           )}
         </section>
       </div>

--- a/src/components/PinnedDropZone.tsx
+++ b/src/components/PinnedDropZone.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { useTodoStore } from '../stores/TodoStoreContext'
+
+interface PinnedDropZoneProps {
+  index: number
+}
+
+const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
+  const store = useTodoStore()
+  const [isOver, setIsOver] = useState(false)
+
+  const draggedId = store.draggedId
+  const isPinnedItem = draggedId !== null && store.isPinned(draggedId)
+  const canAccept = isPinnedItem
+
+  const handleDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    if (!isOver) {
+      setIsOver(true)
+    }
+  }
+
+  const handleDragLeave: React.DragEventHandler<HTMLDivElement> = () => {
+    if (isOver) {
+      setIsOver(false)
+    }
+  }
+
+  const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept || draggedId === null) return
+    event.preventDefault()
+    setIsOver(false)
+    store.movePinned(draggedId, index)
+  }
+
+  const heightClass = canAccept ? 'h-2' : 'h-0'
+  const marginClass = canAccept ? 'my-1' : 'my-0'
+
+  return (
+    <div className="py-0">
+      <div
+        className={[
+          'rounded border border-dashed transition-all duration-150 ease-out',
+          heightClass,
+          marginClass,
+          canAccept ? 'opacity-100 border-slate-300 bg-slate-200/60' : 'opacity-0 border-transparent bg-transparent',
+          isOver && canAccept ? 'border-slate-400 bg-slate-300' : '',
+        ].join(' ')}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        aria-hidden
+      />
+    </div>
+  )
+}
+
+export const PinnedDropZone = observer(PinnedDropZoneComponent)

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import {
+  FiBookmark,
   FiCheck,
   FiCheckCircle,
   FiCircle,
@@ -16,19 +17,20 @@ import { useTodoStore } from '../stores/TodoStoreContext'
 interface TodoItemProps {
   todo: TodoNode
   depth: number
+  allowChildren?: boolean
 }
 
 const actionButtonStyles =
   'rounded-lg p-1.5 text-slate-400 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none'
 
-const TodoItemComponent = ({ todo, depth }: TodoItemProps) => {
+const TodoItemComponent = ({ todo, depth, allowChildren = true }: TodoItemProps) => {
   const store = useTodoStore()
   const [isEditing, setIsEditing] = useState(false)
   const [isAddingChild, setIsAddingChild] = useState(false)
   const [titleDraft, setTitleDraft] = useState(todo.title)
   const [childTitle, setChildTitle] = useState('')
 
-  const canAddChild = depth < MAX_DEPTH
+  const canAddChild = allowChildren && depth < MAX_DEPTH
   const isDragging = store.draggedId === todo.id
 
   useEffect(() => {
@@ -141,6 +143,20 @@ const TodoItemComponent = ({ todo, depth }: TodoItemProps) => {
           <div className="flex items-center gap-1">
             {!isEditing && (
               <>
+                <button
+                  type="button"
+                  onClick={() => store.togglePinned(todo.id)}
+                  className={[
+                    actionButtonStyles,
+                    todo.pinned
+                      ? 'bg-amber-100 text-amber-500 hover:bg-amber-100 hover:text-amber-600'
+                      : '',
+                  ].join(' ')}
+                  aria-label={todo.pinned ? 'Открепить задачу' : 'Закрепить задачу'}
+                  aria-pressed={todo.pinned}
+                >
+                  <FiBookmark />
+                </button>
                 {canAddChild && (
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- add a pinned home tab that lists pinned tasks and toggles with the main todo tree
- allow pinning/unpinning todos while maintaining a dedicated pinned order in the store
- add drag-and-drop drop zones for reordering pinned items without nested levels

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca11e487f083308d900dcf0fb1afd0