### PR TITLE
Add mind map tab and extend nesting support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,13 @@ import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
 import { PinnedDropZone } from './components/PinnedDropZone'
+import { MindMapView } from './components/mindmap/MindMapView'
 import { useTodoStore } from './stores/TodoStoreContext'
 
 const AppComponent = () => {
   const store = useTodoStore()
   const [newTitle, setNewTitle] = useState('')
-  const [activeTab, setActiveTab] = useState<'pinned' | 'all'>('pinned')
+  const [activeTab, setActiveTab] = useState<'pinned' | 'all' | 'mind'>('pinned')
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
@@ -26,7 +27,7 @@ const AppComponent = () => {
           <p className="text-sm font-medium uppercase tracking-wide text-slate-400">Задачи</p>
           <h1 className="mt-2 text-3xl font-semibold text-slate-800">Дерево задач</h1>
           <p className="mt-3 max-w-2xl text-sm text-slate-500">
-            Добавляйте задачи, группируйте их по уровням и перетаскивайте элементы, чтобы быстро управлять приоритетами. Максимальная глубина — три уровня.
+            Добавляйте задачи, группируйте их по уровням и перетаскивайте элементы, чтобы быстро управлять приоритетами. Максимальная глубина — семь уровней.
           </p>
         </header>
 
@@ -77,6 +78,18 @@ const AppComponent = () => {
               >
                 Список задач
               </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab('mind')}
+                className={[
+                  'rounded-xl px-4 py-2 transition focus-visible:outline-none',
+                  activeTab === 'mind'
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700',
+                ].join(' ')}
+              >
+                Mind map
+              </button>
             </div>
           </div>
 
@@ -98,7 +111,7 @@ const AppComponent = () => {
                 </div>
               )}
             </>
-          ) : (
+          ) : activeTab === 'all' ? (
             <>
               <div className="space-y-3">
                 <DropZone parentId={null} depth={0} index={0} />
@@ -116,6 +129,8 @@ const AppComponent = () => {
                 </div>
               )}
             </>
+          ) : (
+            <MindMapView />
           )}
         </section>
       </div>

--- a/src/components/mindmap/MindMapDropZone.tsx
+++ b/src/components/mindmap/MindMapDropZone.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+import type { DragEventHandler } from 'react'
+import { observer } from 'mobx-react-lite'
+import { MAX_DEPTH } from '../../stores/TodoStore'
+import { useTodoStore } from '../../stores/TodoStoreContext'
+
+interface MindMapDropZoneProps {
+  parentId: string | null
+  depth: number
+  index: number
+}
+
+const MindMapDropZoneComponent = ({ parentId, depth, index }: MindMapDropZoneProps) => {
+  const store = useTodoStore()
+  const [isOver, setIsOver] = useState(false)
+
+  if (depth > MAX_DEPTH) {
+    return null
+  }
+
+  const draggedId = store.draggedId
+  const canAccept = draggedId !== null && store.canDrop(draggedId, parentId)
+  const showPlaceholder = draggedId !== null && depth <= MAX_DEPTH
+
+  const handleDragOver: DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    if (!isOver) {
+      setIsOver(true)
+    }
+  }
+
+  const handleDragLeave: DragEventHandler<HTMLDivElement> = () => {
+    if (isOver) {
+      setIsOver(false)
+    }
+  }
+
+  const handleDrop: DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept || draggedId === null) return
+    event.preventDefault()
+    setIsOver(false)
+    store.moveTodo(draggedId, parentId, index)
+  }
+
+  return (
+    <div
+      className={[
+        'flex h-12 items-center justify-center transition-all duration-150',
+        showPlaceholder ? 'w-24' : 'w-0',
+      ].join(' ')}
+    >
+      <div
+        className={[
+          'flex h-10 w-24 items-center justify-center rounded-2xl border border-dashed text-xs font-medium transition-all duration-150',
+          showPlaceholder ? 'scale-100 opacity-100' : 'pointer-events-none scale-90 opacity-0',
+          canAccept ? 'border-indigo-300 bg-indigo-100/60 text-indigo-500' : 'border-transparent bg-transparent text-transparent',
+          isOver && canAccept ? 'border-indigo-400 bg-indigo-100 text-indigo-600' : '',
+        ].join(' ')}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+        aria-hidden={!showPlaceholder}
+      >
+        Перетащите сюда
+      </div>
+    </div>
+  )
+}
+
+export const MindMapDropZone = observer(MindMapDropZoneComponent)

--- a/src/components/mindmap/MindMapNode.tsx
+++ b/src/components/mindmap/MindMapNode.tsx
@@ -1,0 +1,249 @@
+import { Fragment, useEffect, useMemo, useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import {
+  FiCheck,
+  FiCheckCircle,
+  FiCircle,
+  FiEdit2,
+  FiPlus,
+  FiStar,
+  FiTrash2,
+  FiX,
+} from 'react-icons/fi'
+import { MAX_DEPTH } from '../../stores/TodoStore'
+import { useTodoStore } from '../../stores/TodoStoreContext'
+import { MindMapDropZone } from './MindMapDropZone'
+import type { MindMapBranch } from './tree'
+
+interface MindMapNodeProps {
+  branch: MindMapBranch
+  depth: number
+}
+
+const actionButtonStyles =
+  'rounded-lg p-1.5 text-slate-400 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none'
+
+const MindMapNodeComponent = ({ branch, depth }: MindMapNodeProps) => {
+  const { node, children } = branch
+  const store = useTodoStore()
+  const [isEditing, setIsEditing] = useState(false)
+  const [isAddingChild, setIsAddingChild] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(node.title)
+  const [childTitle, setChildTitle] = useState('')
+
+  const canAddChild = depth < MAX_DEPTH
+  const isDragging = store.draggedId === node.id
+  const hasVisibleChildren = children.length > 0
+  const showChildrenArea = hasVisibleChildren || (canAddChild && store.draggedId !== null)
+
+  useEffect(() => {
+    setTitleDraft(node.title)
+  }, [node.title])
+
+  const handleToggle = () => {
+    store.toggleTodo(node.id)
+  }
+
+  const handleEditSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    store.updateTitle(node.id, titleDraft)
+    setIsEditing(false)
+  }
+
+  const handleAddChild: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    store.addTodo(node.id, childTitle)
+    setChildTitle('')
+    setIsAddingChild(false)
+  }
+
+  const handleDelete = () => {
+    store.deleteTodo(node.id)
+  }
+
+  const handleTogglePinned = () => {
+    store.togglePinned(node.id)
+  }
+
+  const handleDragStart: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (isEditing || isAddingChild) return
+    store.setDragged(node.id)
+    event.dataTransfer.setData('text/plain', node.id)
+    event.dataTransfer.effectAllowed = 'move'
+  }
+
+  const handleDragEnd: React.DragEventHandler<HTMLDivElement> = () => {
+    store.clearDragged()
+  }
+
+  const titleStyles = useMemo(
+    () =>
+      [
+        'text-base font-medium leading-snug transition-colors',
+        node.completed ? 'text-slate-400 line-through' : 'text-slate-700',
+      ].join(' '),
+    [node.completed],
+  )
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <div
+        className={[
+          'group relative flex min-w-[220px] max-w-xs flex-col rounded-2xl border border-slate-200 bg-white/95 p-4 text-left shadow-sm ring-1 ring-white/70 transition-all duration-200',
+          isDragging ? 'opacity-60 ring-2 ring-indigo-200' : 'hover:shadow-md',
+        ].join(' ')}
+        draggable={!isEditing && !isAddingChild}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="flex items-start gap-3">
+          <button
+            type="button"
+            onClick={handleToggle}
+            className={`${actionButtonStyles} -ml-1.5 text-xl text-slate-500`}
+            aria-label={node.completed ? 'Отметить как невыполненную' : 'Отметить как выполненную'}
+          >
+            {node.completed ? <FiCheckCircle /> : <FiCircle />}
+          </button>
+
+          <div className="flex-1">
+            {isEditing ? (
+              <form onSubmit={handleEditSubmit} className="flex flex-col gap-3">
+                <input
+                  className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-slate-400 focus:outline-none"
+                  autoFocus
+                  value={titleDraft}
+                  onChange={(event) => setTitleDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      setTitleDraft(node.title)
+                      setIsEditing(false)
+                    }
+                  }}
+                  placeholder="Название задачи"
+                />
+                <div className="flex items-center gap-1">
+                  <button
+                    type="submit"
+                    className={`${actionButtonStyles} bg-emerald-500 text-white hover:bg-emerald-500/90`}
+                    aria-label="Сохранить название"
+                  >
+                    <FiCheck />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setTitleDraft(node.title)
+                      setIsEditing(false)
+                    }}
+                    className={`${actionButtonStyles} hover:bg-slate-200`}
+                    aria-label="Отменить редактирование"
+                  >
+                    <FiX />
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <p className={titleStyles}>{node.title}</p>
+            )}
+          </div>
+
+          <div className="flex items-center gap-1">
+            {!isEditing && (
+              <>
+                <button
+                  type="button"
+                  onClick={handleTogglePinned}
+                  className={[
+                    actionButtonStyles,
+                    node.pinned ? 'text-amber-500 hover:text-amber-500' : '',
+                  ].join(' ')}
+                  aria-label={node.pinned ? 'Открепить задачу' : 'Закрепить задачу'}
+                  aria-pressed={node.pinned}
+                >
+                  <FiStar className={node.pinned ? 'text-amber-500' : undefined} />
+                </button>
+                {canAddChild && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setIsAddingChild((value) => !value)
+                    }}
+                    className={actionButtonStyles}
+                    aria-label={isAddingChild ? 'Скрыть форму добавления подзадачи' : 'Добавить подзадачу'}
+                  >
+                    <FiPlus />
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setIsEditing(true)}
+                  className={actionButtonStyles}
+                  aria-label="Редактировать задачу"
+                >
+                  <FiEdit2 />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDelete}
+                  className={`${actionButtonStyles} text-rose-400 hover:text-rose-600`}
+                  aria-label="Удалить задачу"
+                >
+                  <FiTrash2 />
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        {canAddChild && isAddingChild && (
+          <form onSubmit={handleAddChild} className="mt-4 flex items-center gap-2 rounded-xl bg-slate-50 px-3 py-2">
+            <input
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+              value={childTitle}
+              onChange={(event) => setChildTitle(event.target.value)}
+              placeholder="Новая подзадача"
+            />
+            <div className="flex items-center gap-1">
+              <button
+                type="submit"
+                className={`${actionButtonStyles} bg-emerald-500 text-white hover:bg-emerald-500/90`}
+                aria-label="Добавить подзадачу"
+              >
+                <FiCheck />
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setChildTitle('')
+                  setIsAddingChild(false)
+                }}
+                className={actionButtonStyles}
+                aria-label="Отменить добавление подзадачи"
+              >
+                <FiX />
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+
+      {showChildrenArea && (
+        <div className="flex flex-col items-center">
+          <div className="h-6 w-px bg-slate-300" />
+          <div className="mt-6 flex flex-wrap justify-center gap-6">
+            <MindMapDropZone parentId={node.id} depth={depth + 1} index={0} />
+            {children.map((childBranch, childIndex) => (
+              <Fragment key={childBranch.node.id}>
+                <MindMapNode branch={childBranch} depth={depth + 1} />
+                <MindMapDropZone parentId={node.id} depth={depth + 1} index={childIndex + 1} />
+              </Fragment>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const MindMapNode = observer(MindMapNodeComponent)

--- a/src/components/mindmap/MindMapView.tsx
+++ b/src/components/mindmap/MindMapView.tsx
@@ -1,0 +1,55 @@
+import { Fragment, useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { useTodoStore } from '../../stores/TodoStoreContext'
+import { MindMapDropZone } from './MindMapDropZone'
+import { MindMapNode } from './MindMapNode'
+import { buildMindMapBranches } from './tree'
+
+const MindMapViewComponent = () => {
+  const store = useTodoStore()
+  const [hideCompleted, setHideCompleted] = useState(false)
+
+  const branches = buildMindMapBranches(store.todos, hideCompleted)
+  const hasTodos = branches.length > 0
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl bg-white/80 px-4 py-3 text-sm text-slate-600 shadow-sm ring-1 ring-slate-200/70">
+        <p className="font-medium text-slate-700">Mind map</p>
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-400"
+            checked={hideCompleted}
+            onChange={(event) => setHideCompleted(event.target.checked)}
+          />
+          <span>Скрывать выполненные подпункты</span>
+        </label>
+      </div>
+
+      <div className="relative flex-1 overflow-auto rounded-3xl bg-gradient-to-br from-white/90 via-white to-slate-100/70 p-6 shadow-inner ring-1 ring-white/60">
+        <div className="mx-auto flex min-h-[320px] w-full max-w-full flex-col items-center gap-6">
+          <div className="flex flex-wrap justify-center gap-6">
+            <MindMapDropZone parentId={null} depth={0} index={0} />
+            {branches.map((branch, index) => (
+              <Fragment key={branch.node.id}>
+                <MindMapNode branch={branch} depth={0} />
+                <MindMapDropZone parentId={null} depth={0} index={index + 1} />
+              </Fragment>
+            ))}
+          </div>
+
+          {!hasTodos && (
+            <div className="mt-8 max-w-xl rounded-2xl border border-dashed border-slate-300/80 bg-white/80 px-6 py-8 text-center text-sm text-slate-500">
+              {hideCompleted
+                ? 'Все завершенные ветки скрыты. Отключите фильтр, чтобы увидеть выполненные задачи.'
+                : 'Добавьте задачи и подзадачи — мы построим mind map автоматически.'}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const MindMapView = observer(MindMapViewComponent)

--- a/src/components/mindmap/tree.ts
+++ b/src/components/mindmap/tree.ts
@@ -1,0 +1,35 @@
+import type { TodoNode } from '../../stores/TodoStore'
+
+export interface MindMapBranch {
+  node: TodoNode
+  children: MindMapBranch[]
+}
+
+const isNodeTreeCompleted = (node: TodoNode): boolean => {
+  if (!node.completed) {
+    return false
+  }
+
+  return node.children.every((child) => isNodeTreeCompleted(child))
+}
+
+export const buildMindMapBranches = (
+  nodes: TodoNode[],
+  hideCompleted: boolean,
+): MindMapBranch[] => {
+  const branches: MindMapBranch[] = []
+
+  nodes.forEach((node) => {
+    const children = buildMindMapBranches(node.children, hideCompleted)
+    const allChildrenCompleted =
+      node.children.length > 0 && node.children.every((child) => isNodeTreeCompleted(child))
+
+    const shouldHide = hideCompleted && (node.completed || allChildrenCompleted) && children.length === 0
+
+    if (!shouldHide) {
+      branches.push({ node, children })
+    }
+  })
+
+  return branches
+}

--- a/src/stores/TodoStore.ts
+++ b/src/stores/TodoStore.ts
@@ -15,7 +15,7 @@ interface TodoLookup {
   index: number
 }
 
-export const MAX_DEPTH = 2
+export const MAX_DEPTH = 6
 
 export class TodoStore {
   todos: TodoNode[] = []


### PR DESCRIPTION
## Summary
- raise the nested todo depth limit to seven levels and update the list view copy
- introduce a mind map tab with editable, draggable nodes and drop zones for restructuring
- allow hiding fully completed branches so the mind map focuses on active work

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca1621e604833084f70ad20e8cacd9