### PR TITLE
feat: add pinned lists management

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,8 @@ import { observer } from 'mobx-react-lite'
 import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
-import { PinnedDropZone } from './components/PinnedDropZone'
 import { useTodoStore } from './stores/TodoStoreContext'
+import { PinnedList } from './components/PinnedList'
 
 const AppComponent = () => {
   const store = useTodoStore()
@@ -17,7 +17,8 @@ const AppComponent = () => {
     setNewTitle('')
   }
 
-  const pinnedTodos = store.pinnedTodos
+  const pinnedLists = store.pinnedListData
+  const hasPinnedTodos = pinnedLists.some((list) => list.todos.length > 0)
 
   return (
     <div className="min-h-screen bg-canvas-light text-slate-900">
@@ -82,19 +83,25 @@ const AppComponent = () => {
 
           {activeTab === 'pinned' ? (
             <>
-              {pinnedTodos.length > 0 ? (
-                <div className="space-y-3">
-                  <PinnedDropZone index={0} />
-                  {pinnedTodos.map((todo, index) => (
-                    <Fragment key={todo.id}>
-                      <TodoItem todo={todo} depth={0} allowChildren={false} />
-                      <PinnedDropZone index={index + 1} />
-                    </Fragment>
-                  ))}
-                </div>
-              ) : (
-                <div className="rounded-2xl border border-dashed border-amber-200 bg-white/80 px-6 py-10 text-center text-sm text-slate-500">
-                  Закрепите важные задачи на вкладке «Список задач», чтобы быстро возвращаться к ним.
+              <div className="mb-4 flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => store.addPinnedList()}
+                  className="flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+                >
+                  <FiPlus /> Новый список
+                </button>
+              </div>
+
+              <div className="flex flex-1 gap-4 overflow-x-auto pb-2">
+                {pinnedLists.map((list) => (
+                  <PinnedList key={list.id} {...list} />
+                ))}
+              </div>
+
+              {!hasPinnedTodos && (
+                <div className="mt-6 rounded-2xl border border-dashed border-amber-200 bg-white/80 px-6 py-10 text-center text-sm text-slate-500">
+                  Закрепите важные задачи на вкладке «Список задач», затем распределяйте их по спискам и перетаскивайте между ними.
                 </div>
               )}
             </>

--- a/src/components/PinnedDropZone.tsx
+++ b/src/components/PinnedDropZone.tsx
@@ -3,10 +3,11 @@ import { observer } from 'mobx-react-lite'
 import { useTodoStore } from '../stores/TodoStoreContext'
 
 interface PinnedDropZoneProps {
+  listId: string
   index: number
 }
 
-const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
+const PinnedDropZoneComponent = ({ listId, index }: PinnedDropZoneProps) => {
   const store = useTodoStore()
   const [isOver, setIsOver] = useState(false)
 
@@ -33,21 +34,16 @@ const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
     if (!canAccept || draggedId === null) return
     event.preventDefault()
     setIsOver(false)
-    store.movePinnedTodo(draggedId, index)
+    store.movePinnedTodo(draggedId, listId, index)
     store.clearDragged()
   }
-
-  const heightClass = showPlaceholder ? 'h-2' : 'h-0'
-  const marginClass = showPlaceholder ? 'my-1' : 'my-0'
 
   return (
     <div className="py-0">
       <div
         className={[
           'rounded border border-dashed transition-all duration-150 ease-out',
-          heightClass,
-          marginClass,
-          showPlaceholder ? 'opacity-100' : 'opacity-0',
+          showPlaceholder ? 'my-2 h-2 opacity-100' : 'my-0 h-0 opacity-0',
           canAccept ? 'border-amber-300 bg-amber-200/40' : 'border-transparent bg-transparent',
           isOver && canAccept ? 'border-amber-400 bg-amber-200/70' : '',
         ].join(' ')}

--- a/src/components/PinnedList.tsx
+++ b/src/components/PinnedList.tsx
@@ -1,0 +1,116 @@
+import { Fragment, useEffect, useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { FiCheck, FiEdit2, FiTrash2, FiX } from 'react-icons/fi'
+import { TodoItem } from './TodoItem'
+import { PinnedDropZone } from './PinnedDropZone'
+import { useTodoStore } from '../stores/TodoStoreContext'
+import type { TodoNode } from '../stores/TodoStore'
+
+interface PinnedListProps {
+  id: string
+  title: string
+  todos: TodoNode[]
+  isFirst: boolean
+}
+
+const actionButtonStyles =
+  'rounded-lg p-1.5 text-slate-400 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none'
+
+const PinnedListComponent = ({ id, title, todos, isFirst }: PinnedListProps) => {
+  const store = useTodoStore()
+  const [isRenaming, setIsRenaming] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(title)
+
+  useEffect(() => {
+    setTitleDraft(title)
+  }, [title])
+
+  const handleRenameSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    store.renamePinnedList(id, titleDraft)
+    setIsRenaming(false)
+  }
+
+  const handleDelete = () => {
+    store.removePinnedList(id)
+  }
+
+  return (
+    <div className="flex w-72 flex-col rounded-3xl bg-white/90 p-4 shadow-inner ring-1 ring-slate-200/80">
+      <div className="mb-3 flex items-center gap-2">
+        {isRenaming ? (
+          <form onSubmit={handleRenameSubmit} className="flex flex-1 items-center gap-2">
+            <input
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-slate-400 focus:outline-none"
+              value={titleDraft}
+              onChange={(event) => setTitleDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  setTitleDraft(title)
+                  setIsRenaming(false)
+                }
+              }}
+              autoFocus
+            />
+            <button
+              type="submit"
+              className={`${actionButtonStyles} bg-emerald-500 text-white hover:bg-emerald-500/90`}
+              aria-label="Сохранить название списка"
+            >
+              <FiCheck />
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setTitleDraft(title)
+                setIsRenaming(false)
+              }}
+              className={`${actionButtonStyles} hover:bg-slate-200`}
+              aria-label="Отменить переименование"
+            >
+              <FiX />
+            </button>
+          </form>
+        ) : (
+          <>
+            <h3 className="flex-1 text-base font-semibold text-slate-700">{title}</h3>
+            <button
+              type="button"
+              onClick={() => setIsRenaming(true)}
+              className={actionButtonStyles}
+              aria-label="Переименовать список"
+            >
+              <FiEdit2 />
+            </button>
+            <button
+              type="button"
+              onClick={handleDelete}
+              className={`${actionButtonStyles} ${isFirst ? 'cursor-not-allowed opacity-40' : 'text-rose-400 hover:text-rose-600'}`}
+              aria-label={isFirst ? 'Нельзя удалить основной список' : 'Удалить список'}
+              disabled={isFirst}
+            >
+              <FiTrash2 />
+            </button>
+          </>
+        )}
+      </div>
+
+      <div className="flex-1 space-y-3">
+        <PinnedDropZone listId={id} index={0} />
+        {todos.map((todo, index) => (
+          <Fragment key={todo.id}>
+            <TodoItem todo={todo} depth={0} allowChildren={false} />
+            <PinnedDropZone listId={id} index={index + 1} />
+          </Fragment>
+        ))}
+        {todos.length === 0 && (
+          <div className="rounded-2xl border border-dashed border-amber-200/60 bg-amber-50/60 px-4 py-6 text-center text-xs text-amber-700">
+            Перетащите закреплённые задачи или добавьте их из списка задач.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const PinnedList = observer(PinnedListComponent)


### PR DESCRIPTION
## Summary
- allow creating, renaming, and removing pinned lists while keeping tasks in the primary list
- enable dragging pinned tasks between lists with dedicated drop zones
- refresh the pinned tab UI to display list columns with helpful empty states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca99d160ec8330b75acd0a9af1dd64