### PR TITLE
Add multi-list support to pinned tasks board

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,15 @@ import { observer } from 'mobx-react-lite'
 import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
-import { PinnedDropZone } from './components/PinnedDropZone'
+import { PinnedListColumn } from './components/PinnedListColumn'
 import { useTodoStore } from './stores/TodoStoreContext'
 
 const AppComponent = () => {
   const store = useTodoStore()
   const [newTitle, setNewTitle] = useState('')
   const [activeTab, setActiveTab] = useState<'pinned' | 'all'>('pinned')
+  const [isCreatingList, setIsCreatingList] = useState(false)
+  const [newListTitle, setNewListTitle] = useState('')
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
@@ -17,7 +19,7 @@ const AppComponent = () => {
     setNewTitle('')
   }
 
-  const pinnedTodos = store.pinnedTodos
+  const pinnedLists = store.pinnedListsView
 
   return (
     <div className="min-h-screen bg-canvas-light text-slate-900">
@@ -82,21 +84,71 @@ const AppComponent = () => {
 
           {activeTab === 'pinned' ? (
             <>
-              {pinnedTodos.length > 0 ? (
-                <div className="space-y-3">
-                  <PinnedDropZone index={0} />
-                  {pinnedTodos.map((todo, index) => (
-                    <Fragment key={todo.id}>
-                      <TodoItem todo={todo} depth={0} allowChildren={false} />
-                      <PinnedDropZone index={index + 1} />
-                    </Fragment>
-                  ))}
-                </div>
-              ) : (
-                <div className="rounded-2xl border border-dashed border-amber-200 bg-white/80 px-6 py-10 text-center text-sm text-slate-500">
-                  Закрепите важные задачи на вкладке «Список задач», чтобы быстро возвращаться к ним.
-                </div>
-              )}
+              <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-slate-500">
+                  Создавайте отдельные списки для закреплённых задач и перетаскивайте элементы между ними.
+                </p>
+                {isCreatingList ? (
+                  <form
+                    onSubmit={(event) => {
+                      event.preventDefault()
+                      const trimmed = newListTitle.trim()
+                      const fallbackTitle = `Список ${pinnedLists.length + 1}`
+                      store.addPinnedList(trimmed || fallbackTitle)
+                      setNewListTitle('')
+                      setIsCreatingList(false)
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <input
+                      className="w-40 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+                      value={newListTitle}
+                      onChange={(event) => setNewListTitle(event.target.value)}
+                      placeholder="Название списка"
+                      autoFocus
+                      onKeyDown={(event) => {
+                        if (event.key === 'Escape') {
+                          setNewListTitle('')
+                          setIsCreatingList(false)
+                        }
+                      }}
+                    />
+                    <div className="flex items-center gap-1">
+                      <button
+                        type="submit"
+                        className="rounded-lg bg-emerald-500 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-emerald-500/90"
+                      >
+                        Сохранить
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setNewListTitle('')
+                          setIsCreatingList(false)
+                        }}
+                        className="rounded-lg px-3 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
+                      >
+                        Отмена
+                      </button>
+                    </div>
+                  </form>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setIsCreatingList(true)}
+                    className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+                  >
+                    <FiPlus />
+                    Новый список
+                  </button>
+                )}
+              </div>
+
+              <div className="flex gap-4 overflow-x-auto pb-2">
+                {pinnedLists.map((list) => (
+                  <PinnedListColumn key={list.id} list={list} />
+                ))}
+              </div>
             </>
           ) : (
             <>

--- a/src/components/PinnedDropZone.tsx
+++ b/src/components/PinnedDropZone.tsx
@@ -3,16 +3,18 @@ import { observer } from 'mobx-react-lite'
 import { useTodoStore } from '../stores/TodoStoreContext'
 
 interface PinnedDropZoneProps {
+  listId: string
   index: number
+  isListEmpty?: boolean
 }
 
-const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
+const PinnedDropZoneComponent = ({ listId, index, isListEmpty = false }: PinnedDropZoneProps) => {
   const store = useTodoStore()
   const [isOver, setIsOver] = useState(false)
 
   const draggedId = store.draggedId
   const canAccept = draggedId !== null && store.isPinned(draggedId)
-  const showPlaceholder = canAccept
+  const shouldDisplay = canAccept || isListEmpty
 
   const handleDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
     if (!canAccept) return
@@ -33,12 +35,19 @@ const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
     if (!canAccept || draggedId === null) return
     event.preventDefault()
     setIsOver(false)
-    store.movePinnedTodo(draggedId, index)
+    store.movePinnedTodo(draggedId, listId, index)
     store.clearDragged()
   }
 
-  const heightClass = showPlaceholder ? 'h-2' : 'h-0'
-  const marginClass = showPlaceholder ? 'my-1' : 'my-0'
+  const heightClass = shouldDisplay ? 'h-10' : 'h-0'
+  const marginClass = shouldDisplay ? 'my-2' : 'my-0'
+  const opacityClass = shouldDisplay ? 'opacity-100' : 'opacity-0'
+  const baseStyles = isListEmpty
+    ? 'border-slate-200/80 bg-white/90'
+    : canAccept
+      ? 'border-amber-300 bg-amber-200/40'
+      : 'border-transparent bg-transparent'
+  const activeStyles = isOver && canAccept ? 'border-amber-400 bg-amber-200/70' : ''
 
   return (
     <div className="py-0">
@@ -47,9 +56,9 @@ const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
           'rounded border border-dashed transition-all duration-150 ease-out',
           heightClass,
           marginClass,
-          showPlaceholder ? 'opacity-100' : 'opacity-0',
-          canAccept ? 'border-amber-300 bg-amber-200/40' : 'border-transparent bg-transparent',
-          isOver && canAccept ? 'border-amber-400 bg-amber-200/70' : '',
+          opacityClass,
+          baseStyles,
+          activeStyles,
         ].join(' ')}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}

--- a/src/components/PinnedListColumn.tsx
+++ b/src/components/PinnedListColumn.tsx
@@ -1,0 +1,139 @@
+import { Fragment, useEffect, useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { FiCheck, FiEdit2, FiTrash2, FiX } from 'react-icons/fi'
+import { TodoItem } from './TodoItem'
+import { PinnedDropZone } from './PinnedDropZone'
+import { type PinnedList, type TodoNode } from '../stores/TodoStore'
+import { useTodoStore } from '../stores/TodoStoreContext'
+
+interface PinnedListWithTodos extends PinnedList {
+  todos: TodoNode[]
+}
+
+interface PinnedListColumnProps {
+  list: PinnedListWithTodos
+}
+
+const actionButtonStyles =
+  'rounded-lg p-1.5 text-slate-400 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none'
+
+const PinnedListColumnComponent = ({ list }: PinnedListColumnProps) => {
+  const store = useTodoStore()
+  const [isEditing, setIsEditing] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(list.title)
+
+  useEffect(() => {
+    if (!isEditing) {
+      setTitleDraft(list.title)
+    }
+  }, [isEditing, list.title])
+
+  const isPinnedDragging = store.draggedId ? store.isPinned(store.draggedId) : false
+
+  const handleRenameSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    store.renamePinnedList(list.id, titleDraft)
+    setIsEditing(false)
+  }
+
+  const handleDeleteList = () => {
+    store.removePinnedList(list.id)
+  }
+
+  const showEmptyMessage = list.todos.length === 0
+
+  return (
+    <div
+      className={[
+        'flex w-72 flex-col gap-4 rounded-3xl bg-white/80 p-4 shadow-sm ring-1 ring-slate-200 transition-all duration-200',
+        isPinnedDragging ? 'ring-amber-200/70' : '',
+      ].join(' ')}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1">
+          {isEditing ? (
+            <form onSubmit={handleRenameSubmit} className="flex items-center gap-2">
+              <input
+                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+                value={titleDraft}
+                onChange={(event) => setTitleDraft(event.target.value)}
+                autoFocus
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape') {
+                    setTitleDraft(list.title)
+                    setIsEditing(false)
+                  }
+                }}
+                placeholder="Название списка"
+              />
+              <div className="flex items-center gap-1">
+                <button
+                  type="submit"
+                  className={`${actionButtonStyles} bg-emerald-500 text-white hover:bg-emerald-500/90`}
+                  aria-label="Сохранить название списка"
+                >
+                  <FiCheck />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setTitleDraft(list.title)
+                    setIsEditing(false)
+                  }}
+                  className={actionButtonStyles}
+                  aria-label="Отменить переименование"
+                >
+                  <FiX />
+                </button>
+              </div>
+            </form>
+          ) : (
+            <h3 className="text-base font-semibold text-slate-700">{list.title}</h3>
+          )}
+        </div>
+
+        {!isEditing && (
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              className={actionButtonStyles}
+              aria-label="Переименовать список"
+            >
+              <FiEdit2 />
+            </button>
+            {!list.locked && (
+              <button
+                type="button"
+                onClick={handleDeleteList}
+                className={`${actionButtonStyles} text-rose-400 hover:text-rose-600`}
+                aria-label="Удалить список"
+              >
+                <FiTrash2 />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex-1 space-y-3">
+        <PinnedDropZone listId={list.id} index={0} isListEmpty={list.todos.length === 0} />
+
+        {showEmptyMessage ? (
+          <div className="rounded-2xl border border-dashed border-slate-200/80 bg-white/60 px-3 py-6 text-center text-sm text-slate-400">
+            Перетащите сюда закреплённую задачу или закрепите новую во вкладке «Список задач».
+          </div>
+        ) : (
+          list.todos.map((todo, index) => (
+            <Fragment key={todo.id}>
+              <TodoItem todo={todo} depth={0} allowChildren={false} />
+              <PinnedDropZone listId={list.id} index={index + 1} />
+            </Fragment>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const PinnedListColumn = observer(PinnedListColumnComponent)


### PR DESCRIPTION
## Summary
- render the pinned tab as a set of horizontal lists with drag-and-drop between them
- add a column component with rename/delete controls and an inline form to create new pinned lists
- extend the store and drop zones to track per-list pinned order and move items back to the primary list when a list is removed

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ca99d160ec8330b75acd0a9af1dd64