### PR TITLE
Add multi-list management for pinned tasks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,17 @@
-import { Fragment, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
-import { PinnedDropZone } from './components/PinnedDropZone'
+import { PinnedList } from './components/PinnedList'
 import { useTodoStore } from './stores/TodoStoreContext'
 
 const AppComponent = () => {
   const store = useTodoStore()
   const [newTitle, setNewTitle] = useState('')
   const [activeTab, setActiveTab] = useState<'pinned' | 'all'>('pinned')
+  const [isAddingPinnedList, setIsAddingPinnedList] = useState(false)
+  const [newPinnedListTitle, setNewPinnedListTitle] = useState('')
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
@@ -17,7 +19,26 @@ const AppComponent = () => {
     setNewTitle('')
   }
 
-  const pinnedTodos = store.pinnedTodos
+  const handlePinnedListSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    const trimmed = newPinnedListTitle.trim()
+    if (!trimmed) return
+    store.addPinnedList(trimmed)
+    setNewPinnedListTitle('')
+    setIsAddingPinnedList(false)
+  }
+
+  const cancelPinnedListCreation = () => {
+    setNewPinnedListTitle('')
+    setIsAddingPinnedList(false)
+  }
+
+  const pinnedLists = store.pinnedListsWithTodos
+  const totalPinned = useMemo(
+    () => pinnedLists.reduce((accumulator, list) => accumulator + list.todos.length, 0),
+    [pinnedLists],
+  )
+  const isPinnedListTitleValid = newPinnedListTitle.trim().length > 0
 
   return (
     <div className="min-h-screen bg-canvas-light text-slate-900">
@@ -82,18 +103,60 @@ const AppComponent = () => {
 
           {activeTab === 'pinned' ? (
             <>
-              {pinnedTodos.length > 0 ? (
-                <div className="space-y-3">
-                  <PinnedDropZone index={0} />
-                  {pinnedTodos.map((todo, index) => (
-                    <Fragment key={todo.id}>
-                      <TodoItem todo={todo} depth={0} allowChildren={false} />
-                      <PinnedDropZone index={index + 1} />
-                    </Fragment>
-                  ))}
-                </div>
-              ) : (
-                <div className="rounded-2xl border border-dashed border-amber-200 bg-white/80 px-6 py-10 text-center text-sm text-slate-500">
+              <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <h2 className="text-base font-semibold text-slate-600">Списки закрепленных задач</h2>
+                {isAddingPinnedList ? (
+                  <form
+                    onSubmit={handlePinnedListSubmit}
+                    className="flex flex-col gap-2 rounded-2xl border border-slate-200 bg-white/80 p-3 shadow-sm sm:flex-row sm:items-center"
+                  >
+                    <input
+                      className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+                      placeholder="Название нового списка"
+                      value={newPinnedListTitle}
+                      onChange={(event) => setNewPinnedListTitle(event.target.value)}
+                    />
+                    <div className="flex items-center gap-2 self-end sm:self-auto">
+                      <button
+                        type="submit"
+                        disabled={!isPinnedListTitleValid}
+                        className={`rounded-lg px-3 py-2 text-sm font-medium text-white transition ${
+                          isPinnedListTitleValid
+                            ? 'bg-slate-900 hover:bg-slate-800'
+                            : 'cursor-not-allowed bg-slate-400'
+                        }`}
+                      >
+                        Создать
+                      </button>
+                      <button
+                        type="button"
+                        onClick={cancelPinnedListCreation}
+                        className="rounded-lg px-3 py-2 text-sm font-medium text-slate-500 transition hover:bg-slate-100"
+                      >
+                        Отмена
+                      </button>
+                    </div>
+                  </form>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setIsAddingPinnedList(true)}
+                    className="flex items-center gap-2 rounded-xl border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-400 hover:bg-white"
+                  >
+                    <FiPlus />
+                    Новый список
+                  </button>
+                )}
+              </div>
+
+              <div className="space-y-4">
+                {pinnedLists.map((list) => (
+                  <PinnedList key={list.id} list={list} />
+                ))}
+              </div>
+
+              {totalPinned === 0 && (
+                <div className="mt-6 rounded-2xl border border-dashed border-amber-200 bg-white/80 px-6 py-10 text-center text-sm text-slate-500">
                   Закрепите важные задачи на вкладке «Список задач», чтобы быстро возвращаться к ним.
                 </div>
               )}

--- a/src/components/PinnedDropZone.tsx
+++ b/src/components/PinnedDropZone.tsx
@@ -3,10 +3,11 @@ import { observer } from 'mobx-react-lite'
 import { useTodoStore } from '../stores/TodoStoreContext'
 
 interface PinnedDropZoneProps {
+  listId: string
   index: number
 }
 
-const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
+const PinnedDropZoneComponent = ({ listId, index }: PinnedDropZoneProps) => {
   const store = useTodoStore()
   const [isOver, setIsOver] = useState(false)
 
@@ -33,7 +34,7 @@ const PinnedDropZoneComponent = ({ index }: PinnedDropZoneProps) => {
     if (!canAccept || draggedId === null) return
     event.preventDefault()
     setIsOver(false)
-    store.movePinnedTodo(draggedId, index)
+    store.movePinnedTodo(draggedId, listId, index)
     store.clearDragged()
   }
 

--- a/src/components/PinnedList.tsx
+++ b/src/components/PinnedList.tsx
@@ -1,0 +1,137 @@
+import { Fragment, useEffect, useMemo, useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { FiCheck, FiEdit2, FiTrash2, FiX } from 'react-icons/fi'
+import { TodoItem } from './TodoItem'
+import { PinnedDropZone } from './PinnedDropZone'
+import { useTodoStore } from '../stores/TodoStoreContext'
+import type { PinnedListView } from '../stores/TodoStore'
+
+interface PinnedListProps {
+  list: PinnedListView
+}
+
+const headerButtonStyles =
+  'rounded-lg p-1.5 text-slate-400 transition-colors duration-150 hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none'
+
+const actionConfirmButtonStyles = `${headerButtonStyles} bg-emerald-500 text-white hover:bg-emerald-500/90`
+
+const PinnedListComponent = ({ list }: PinnedListProps) => {
+  const store = useTodoStore()
+  const [isEditingTitle, setIsEditingTitle] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(list.title)
+
+  const isPrimary = store.isPrimaryPinnedList(list.id)
+  const todos = list.todos
+  const isRenameValid = titleDraft.trim().length > 0
+
+  useEffect(() => {
+    setTitleDraft(list.title)
+  }, [list.title])
+
+  const emptyStateMessage = useMemo(() => {
+    if (isPrimary) {
+      return 'Закрепите важные задачи на вкладке «Список задач», чтобы быстро возвращаться к ним.'
+    }
+    return 'Перетащите закрепленные задачи, чтобы начать заполнять этот список.'
+  }, [isPrimary])
+
+  const handleRenameSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    const trimmed = titleDraft.trim()
+    if (!trimmed) return
+    store.renamePinnedList(list.id, trimmed)
+    setIsEditingTitle(false)
+  }
+
+  return (
+    <div className="flex flex-col rounded-2xl bg-white/90 p-4 shadow-sm ring-1 ring-slate-200">
+      <div className="flex items-start gap-2">
+        {isEditingTitle ? (
+          <form onSubmit={handleRenameSubmit} className="flex flex-1 items-center gap-2">
+            <input
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-sm focus:border-slate-400 focus:outline-none"
+              autoFocus
+              value={titleDraft}
+              onChange={(event) => setTitleDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  setTitleDraft(list.title)
+                  setIsEditingTitle(false)
+                }
+              }}
+              placeholder="Название списка"
+            />
+            <div className="flex items-center gap-1">
+              <button
+                type="submit"
+                disabled={!isRenameValid}
+                className={`${
+                  isRenameValid
+                    ? actionConfirmButtonStyles
+                    : `${actionConfirmButtonStyles} cursor-not-allowed opacity-60`
+                }`}
+                aria-label="Сохранить название списка"
+              >
+                <FiCheck />
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setTitleDraft(list.title)
+                  setIsEditingTitle(false)
+                }}
+                className={headerButtonStyles}
+                aria-label="Отменить переименование"
+              >
+                <FiX />
+              </button>
+            </div>
+          </form>
+        ) : (
+          <>
+            <h3 className="flex-1 text-sm font-semibold text-slate-700">{list.title}</h3>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => setIsEditingTitle(true)}
+                className={headerButtonStyles}
+                aria-label="Переименовать список"
+              >
+                <FiEdit2 />
+              </button>
+              <button
+                type="button"
+                onClick={() => store.deletePinnedList(list.id)}
+                className={`${headerButtonStyles} ${
+                  isPrimary ? 'cursor-not-allowed opacity-40 hover:bg-transparent hover:text-slate-400' : 'text-rose-400 hover:text-rose-600'
+                }`}
+                aria-label={isPrimary ? 'Первый список нельзя удалить' : 'Удалить список'}
+                disabled={isPrimary}
+              >
+                <FiTrash2 />
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      <div className="mt-4 space-y-3">
+        <PinnedDropZone listId={list.id} index={0} />
+        {todos.map((todo, index) => (
+          <Fragment key={todo.id}>
+            <TodoItem todo={todo} depth={0} allowChildren={false} />
+            <PinnedDropZone listId={list.id} index={index + 1} />
+          </Fragment>
+        ))}
+      </div>
+
+      {todos.length === 0 && (
+        <div className="mt-4 rounded-xl border border-dashed border-amber-200 bg-amber-50/60 px-4 py-6 text-center text-xs text-amber-600">
+          {emptyStateMessage}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const PinnedList = observer(PinnedListComponent)


### PR DESCRIPTION
## Summary
- add UI to create, rename, and delete pinned lists while showing drag targets per list
- refactor the todo store to maintain multiple pinned lists and move tasks back to the primary list when necessary
- update pinned drop zones to allow dragging tasks between pinned lists

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68ca99d160ec8330b75acd0a9af1dd64