### PR TITLE
Add interactive mind map view for todos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "d3": "^7.9.0",
         "mobx": "^6.13.7",
         "mobx-react-lite": "^4.1.0",
         "react": "^19.1.1",
@@ -2168,6 +2169,416 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2192,6 +2603,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2765,6 +3185,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2800,6 +3232,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -3698,6 +4139,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.50.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
@@ -3762,6 +4209,18 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "d3": "^7.9.0",
     "mobx": "^6.13.7",
     "mobx-react-lite": "^4.1.0",
     "react": "^19.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,13 @@ import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
 import { PinnedDropZone } from './components/PinnedDropZone'
+import { MindMapView } from './components/MindMapView'
 import { useTodoStore } from './stores/TodoStoreContext'
 
 const AppComponent = () => {
   const store = useTodoStore()
   const [newTitle, setNewTitle] = useState('')
-  const [activeTab, setActiveTab] = useState<'pinned' | 'all'>('pinned')
+  const [activeTab, setActiveTab] = useState<'pinned' | 'all' | 'mindmap'>('pinned')
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
@@ -26,7 +27,7 @@ const AppComponent = () => {
           <p className="text-sm font-medium uppercase tracking-wide text-slate-400">Задачи</p>
           <h1 className="mt-2 text-3xl font-semibold text-slate-800">Дерево задач</h1>
           <p className="mt-3 max-w-2xl text-sm text-slate-500">
-            Добавляйте задачи, группируйте их по уровням и перетаскивайте элементы, чтобы быстро управлять приоритетами. Максимальная глубина — три уровня.
+            Добавляйте задачи, группируйте их по уровням и перетаскивайте элементы, чтобы быстро управлять приоритетами. Максимальная глубина — семь уровней.
           </p>
         </header>
 
@@ -77,6 +78,18 @@ const AppComponent = () => {
               >
                 Список задач
               </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab('mindmap')}
+                className={[
+                  'rounded-xl px-4 py-2 transition focus-visible:outline-none',
+                  activeTab === 'mindmap'
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700',
+                ].join(' ')}
+              >
+                Mind map
+              </button>
             </div>
           </div>
 
@@ -98,7 +111,7 @@ const AppComponent = () => {
                 </div>
               )}
             </>
-          ) : (
+          ) : activeTab === 'all' ? (
             <>
               <div className="space-y-3">
                 <DropZone parentId={null} depth={0} index={0} />
@@ -116,6 +129,8 @@ const AppComponent = () => {
                 </div>
               )}
             </>
+          ) : (
+            <MindMapView />
           )}
         </section>
       </div>

--- a/src/components/MindMapView.tsx
+++ b/src/components/MindMapView.tsx
@@ -1,0 +1,583 @@
+import { useEffect, useMemo, useState } from 'react'
+import { observer } from 'mobx-react-lite'
+import { hierarchy, tree } from 'd3'
+import {
+  FiCheck,
+  FiCheckCircle,
+  FiCircle,
+  FiEdit2,
+  FiPlus,
+  FiTrash2,
+  FiX,
+} from 'react-icons/fi'
+import type { HierarchyPointNode } from 'd3-hierarchy'
+import { MAX_DEPTH, type TodoNode } from '../stores/TodoStore'
+import { useTodoStore } from '../stores/TodoStoreContext'
+
+const NODE_VERTICAL_GAP = 90
+const NODE_HORIZONTAL_GAP = 220
+const MAP_MARGIN = 160
+const DROP_ZONE_OFFSET = 48
+
+type Direction = -1 | 0 | 1
+
+interface MindMapData {
+  id: string
+  title: string
+  completed: boolean
+  parentId: string | null
+  index: number
+  direction: Direction
+  node: TodoNode | null
+  children: MindMapData[]
+}
+
+const buildMindMapChildren = (
+  todos: TodoNode[],
+  parentId: string | null,
+  hideCompleted: boolean,
+  branchDirection: Direction,
+): MindMapData[] => {
+  const result: MindMapData[] = []
+  let visibleTopLevelIndex = 0
+
+  todos.forEach((todo, index) => {
+    const direction: Direction =
+      parentId === null
+        ? (visibleTopLevelIndex % 2 === 0 ? 1 : -1)
+        : branchDirection === 0
+          ? 1
+          : branchDirection
+
+    const children = buildMindMapChildren(todo.children, todo.id, hideCompleted, direction)
+    const shouldInclude = !hideCompleted || !todo.completed || children.length > 0
+    if (!shouldInclude) {
+      return
+    }
+
+    result.push({
+      id: todo.id,
+      title: todo.title,
+      completed: todo.completed,
+      parentId,
+      index,
+      direction,
+      node: todo,
+      children,
+    })
+
+    if (parentId === null) {
+      visibleTopLevelIndex += 1
+    }
+  })
+
+  return result
+}
+
+const buildMindMapData = (todos: TodoNode[], hideCompleted: boolean): MindMapData => ({
+  id: 'root',
+  title: 'Карта задач',
+  completed: false,
+  parentId: null,
+  index: -1,
+  direction: 0,
+  node: null,
+  children: buildMindMapChildren(todos, null, hideCompleted, 0),
+})
+
+const useMindMapLayout = (data: MindMapData) => {
+  const root = useMemo(() => hierarchy(data), [data])
+  const layout = useMemo(() => tree<MindMapData>().nodeSize([NODE_VERTICAL_GAP, NODE_HORIZONTAL_GAP]), [])
+  const layoutRoot = useMemo(() => layout(root), [layout, root])
+
+  const nodes = layoutRoot.descendants()
+  nodes.forEach((node) => {
+    if (node.depth === 0) {
+      node.y = 0
+      return
+    }
+
+    const direction = node.data.direction === 0 ? 1 : node.data.direction
+    node.y = node.depth * NODE_HORIZONTAL_GAP * direction
+  })
+
+  const xValues = nodes.map((node) => node.x)
+  const yValues = nodes.map((node) => node.y)
+  const minX = Math.min(...xValues)
+  const maxX = Math.max(...xValues)
+  const minY = Math.min(...yValues)
+  const maxY = Math.max(...yValues)
+
+  const width = Math.max(320, maxY - minY + MAP_MARGIN * 2)
+  const height = Math.max(320, maxX - minX + MAP_MARGIN * 2)
+  const offsetX = MAP_MARGIN - minX
+  const offsetY = MAP_MARGIN - minY
+
+  return {
+    nodes,
+    links: layoutRoot.links(),
+    dimensions: {
+      width,
+      height,
+      offsetX,
+      offsetY,
+    },
+  }
+}
+
+interface MindMapDropZoneProps {
+  parentId: string | null
+  index: number
+  left: number
+  top: number
+}
+
+const MindMapDropZoneComponent = ({ parentId, index, left, top }: MindMapDropZoneProps) => {
+  const store = useTodoStore()
+  const [isOver, setIsOver] = useState(false)
+  const draggedId = store.draggedId
+
+  const canAccept = draggedId !== null && store.canDrop(draggedId, parentId)
+  const isVisible = draggedId !== null
+
+  const handleDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    if (!isOver) {
+      setIsOver(true)
+    }
+  }
+
+  const handleDragLeave: React.DragEventHandler<HTMLDivElement> = () => {
+    if (isOver) {
+      setIsOver(false)
+    }
+  }
+
+  const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canAccept || draggedId === null) return
+    event.preventDefault()
+    setIsOver(false)
+    store.moveTodo(draggedId, parentId, index)
+  }
+
+  return (
+    <div
+      className={[
+        'pointer-events-none absolute -translate-x-1/2 rounded-full transition-all duration-150 ease-out',
+        isVisible ? 'pointer-events-auto h-3 w-24 opacity-80' : 'h-0 w-0 opacity-0',
+        canAccept ? 'bg-slate-300/80 ring-1 ring-slate-400/60' : 'bg-transparent',
+        isOver && canAccept ? 'bg-slate-400 ring-slate-500' : '',
+      ].join(' ')}
+      style={{ left, top }}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      aria-hidden
+    />
+  )
+}
+
+const MindMapDropZone = observer(MindMapDropZoneComponent)
+
+interface MindMapNodeCardProps {
+  node: HierarchyPointNode<MindMapData>
+  left: number
+  top: number
+  offsetForDropZones: number
+}
+
+const MindMapNodeCardComponent = ({ node, left, top, offsetForDropZones }: MindMapNodeCardProps) => {
+  const store = useTodoStore()
+  const todo = node.data.node as TodoNode
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [isAddingChild, setIsAddingChild] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(todo.title)
+  const [childTitle, setChildTitle] = useState('')
+  const [isChildDropTarget, setIsChildDropTarget] = useState(false)
+
+  useEffect(() => {
+    setTitleDraft(todo.title)
+  }, [todo.title])
+
+  const draggedId = store.draggedId
+  const storeDepth = Math.max(node.depth - 1, 0)
+  const canAddChild = storeDepth < MAX_DEPTH
+  const canDropChild =
+    draggedId !== null &&
+    draggedId !== todo.id &&
+    canAddChild &&
+    store.canDrop(draggedId, todo.id)
+  const currentChildrenCount = todo.children.length
+
+  const handleToggle = () => {
+    store.toggleTodo(todo.id)
+  }
+
+  const handleDelete = () => {
+    store.deleteTodo(todo.id)
+  }
+
+  const handleDragStart: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (isEditing || isAddingChild) return
+    store.setDragged(todo.id)
+    event.dataTransfer.setData('text/plain', todo.id)
+    event.dataTransfer.effectAllowed = 'move'
+  }
+
+  const handleDragEnd: React.DragEventHandler<HTMLDivElement> = () => {
+    store.clearDragged()
+    setIsChildDropTarget(false)
+  }
+
+  const handleDropOnNode: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canDropChild || draggedId === null) return
+    event.preventDefault()
+    setIsChildDropTarget(false)
+    store.moveTodo(draggedId, todo.id, currentChildrenCount)
+  }
+
+  const handleDragOverNode: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canDropChild) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    if (!isChildDropTarget) {
+      setIsChildDropTarget(true)
+    }
+  }
+
+  const handleDragLeaveNode: React.DragEventHandler<HTMLDivElement> = () => {
+    if (isChildDropTarget) {
+      setIsChildDropTarget(false)
+    }
+  }
+
+  const handleEditSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    store.updateTitle(todo.id, titleDraft)
+    setIsEditing(false)
+  }
+
+  const handleAddChildSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    store.addTodo(todo.id, childTitle)
+    setChildTitle('')
+    setIsAddingChild(false)
+  }
+
+  return (
+    <div style={{ left, top }} className="absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center">
+      <MindMapDropZone parentId={node.data.parentId} index={node.data.index} left={left} top={top - offsetForDropZones} />
+      <div
+        className={[
+          'w-56 rounded-2xl border bg-white/95 shadow-lg ring-1 ring-slate-200 transition-all duration-200',
+          todo.completed ? 'opacity-80' : 'opacity-100',
+          isChildDropTarget ? 'ring-2 ring-emerald-400 shadow-emerald-100' : '',
+        ].join(' ')}
+        draggable={!isEditing && !isAddingChild}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+        onDragOver={handleDragOverNode}
+        onDragLeave={handleDragLeaveNode}
+        onDrop={handleDropOnNode}
+      >
+        <div className="flex items-start gap-2 px-4 py-3">
+          <button
+            type="button"
+            onClick={handleToggle}
+            className="rounded-lg p-1.5 text-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none"
+            aria-label={todo.completed ? 'Отметить как невыполненную' : 'Отметить как выполненную'}
+          >
+            {todo.completed ? <FiCheckCircle /> : <FiCircle />}
+          </button>
+
+          <div className="flex-1">
+            {isEditing ? (
+              <form onSubmit={handleEditSubmit} className="flex flex-col gap-2">
+                <input
+                  className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+                  value={titleDraft}
+                  autoFocus
+                  onChange={(event) => setTitleDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Escape') {
+                      setTitleDraft(todo.title)
+                      setIsEditing(false)
+                    }
+                  }}
+                />
+                <div className="flex items-center justify-end gap-1">
+                  <button
+                    type="submit"
+                    className="rounded-lg bg-emerald-500 p-1.5 text-white transition hover:bg-emerald-500/90"
+                    aria-label="Сохранить название"
+                  >
+                    <FiCheck />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setTitleDraft(todo.title)
+                      setIsEditing(false)
+                    }}
+                    className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-600"
+                    aria-label="Отменить редактирование"
+                  >
+                    <FiX />
+                  </button>
+                </div>
+              </form>
+            ) : (
+              <p className={['text-sm font-medium leading-snug', todo.completed ? 'text-slate-400 line-through' : 'text-slate-700'].join(' ')}>
+                {todo.title}
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-2 border-t border-slate-100 px-4 py-2">
+          <div className="flex items-center gap-1">
+            {canAddChild && (
+              <button
+                type="button"
+                onClick={() => setIsAddingChild((value) => !value)}
+                className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none"
+                aria-label={isAddingChild ? 'Скрыть форму добавления подзадачи' : 'Добавить подзадачу'}
+              >
+                <FiPlus />
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-none"
+              aria-label="Редактировать задачу"
+            >
+              <FiEdit2 />
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="rounded-lg p-1.5 text-rose-400 transition hover:bg-rose-100 hover:text-rose-500 focus-visible:outline-none"
+            aria-label="Удалить задачу"
+          >
+            <FiTrash2 />
+          </button>
+        </div>
+
+        {isAddingChild && canAddChild && (
+          <form onSubmit={handleAddChildSubmit} className="flex items-center gap-2 border-t border-slate-100 bg-slate-50 px-4 py-3">
+            <input
+              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+              placeholder="Новая подзадача"
+              value={childTitle}
+              autoFocus
+              onChange={(event) => setChildTitle(event.target.value)}
+            />
+            <div className="flex items-center gap-1">
+              <button
+                type="submit"
+                className="rounded-lg bg-emerald-500 p-1.5 text-white transition hover:bg-emerald-500/90"
+                aria-label="Добавить подзадачу"
+              >
+                <FiCheck />
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setChildTitle('')
+                  setIsAddingChild(false)
+                }}
+                className="rounded-lg p-1.5 text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+                aria-label="Отменить добавление подзадачи"
+              >
+                <FiX />
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+      <MindMapDropZone
+        parentId={node.data.parentId}
+        index={node.data.index + 1}
+        left={left}
+        top={top + offsetForDropZones}
+      />
+    </div>
+  )
+}
+
+const MindMapNodeCard = observer(MindMapNodeCardComponent)
+
+const MindMapViewComponent = () => {
+  const store = useTodoStore()
+  const [hideCompleted, setHideCompleted] = useState(false)
+  const [isAddingRootChild, setIsAddingRootChild] = useState(false)
+  const [rootChildTitle, setRootChildTitle] = useState('')
+
+  const data = buildMindMapData(store.todos, hideCompleted)
+  const { nodes, links, dimensions } = useMindMapLayout(data)
+  const [rootNode, ...otherNodes] = nodes
+
+  const draggedId = store.draggedId
+  const canDropToRoot = draggedId !== null && store.canDrop(draggedId, null)
+
+  const handleRootDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canDropToRoot || draggedId === null) return
+    event.preventDefault()
+    store.moveTodo(draggedId, null, store.todos.length)
+  }
+
+  const handleRootDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
+    if (!canDropToRoot) return
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+  }
+
+  const handleRootChildSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
+    event.preventDefault()
+    store.addTodo(null, rootChildTitle)
+    setRootChildTitle('')
+    setIsAddingRootChild(false)
+  }
+
+  const toggleHideCompleted = () => {
+    setHideCompleted((value) => !value)
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-slate-700">Mind map</h2>
+          <p className="text-sm text-slate-500">Визуализируйте дерево задач и управляйте иерархией через перетаскивание.</p>
+        </div>
+        <button
+          type="button"
+          onClick={toggleHideCompleted}
+          className={[
+            'rounded-xl border px-4 py-2 text-sm font-medium transition focus-visible:outline-none',
+            hideCompleted
+              ? 'border-emerald-500 bg-emerald-500 text-white hover:bg-emerald-500/90'
+              : 'border-slate-300 bg-white text-slate-600 hover:bg-slate-100',
+          ].join(' ')}
+        >
+          {hideCompleted ? 'Показывать выполненные' : 'Скрыть выполненные'}
+        </button>
+      </div>
+
+      <div
+        className="relative flex-1 overflow-auto rounded-3xl border border-slate-200/70 bg-slate-50/70"
+        style={{ minHeight: 480 }}
+      >
+        <div style={{ width: dimensions.width, height: dimensions.height }} className="relative">
+          <svg width={dimensions.width} height={dimensions.height} className="absolute inset-0">
+            <g>
+              {links.map((link, index) => {
+                const sourceX = link.source.x + dimensions.offsetX
+                const sourceY = link.source.y + dimensions.offsetY
+                const targetX = link.target.x + dimensions.offsetX
+                const targetY = link.target.y + dimensions.offsetY
+                const midY = (sourceY + targetY) / 2
+
+                return (
+                  <path
+                    key={`${link.source.data.id}-${link.target.data.id}-${index}`}
+                    d={`M${sourceY},${sourceX} C ${midY},${sourceX} ${midY},${targetX} ${targetY},${targetX}`}
+                    fill="none"
+                    stroke="rgba(100,116,139,0.35)"
+                    strokeWidth={2}
+                  />
+                )
+              })}
+            </g>
+          </svg>
+
+          {rootNode && (
+            <div
+              className="absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center"
+              style={{
+                left: rootNode.y + dimensions.offsetY,
+                top: rootNode.x + dimensions.offsetX,
+              }}
+              onDragOver={handleRootDragOver}
+              onDrop={handleRootDrop}
+            >
+              <MindMapDropZone parentId={null} index={0} left={rootNode.y + dimensions.offsetY} top={rootNode.x + dimensions.offsetX - DROP_ZONE_OFFSET} />
+              <div
+                className={[
+                  'w-64 rounded-3xl bg-slate-900 p-5 text-white shadow-xl ring-1 ring-slate-900/20 transition',
+                  canDropToRoot ? 'ring-2 ring-emerald-400' : '',
+                ].join(' ')}
+              >
+                <h3 className="text-lg font-semibold">Корневой список</h3>
+                <p className="mt-1 text-sm text-slate-200/80">
+                  Перетащите задачу, чтобы сделать её корневой, или создайте новую верхнеуровневую задачу.
+                </p>
+
+                {isAddingRootChild ? (
+                  <form onSubmit={handleRootChildSubmit} className="mt-3 flex gap-2">
+                    <input
+                      className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-slate-400 focus:outline-none"
+                      placeholder="Новая задача"
+                      value={rootChildTitle}
+                      autoFocus
+                      onChange={(event) => setRootChildTitle(event.target.value)}
+                    />
+                    <button
+                      type="submit"
+                      className="rounded-lg bg-emerald-500 p-2 text-white transition hover:bg-emerald-500/90"
+                      aria-label="Добавить задачу"
+                    >
+                      <FiCheck />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setRootChildTitle('')
+                        setIsAddingRootChild(false)
+                      }}
+                      className="rounded-lg bg-white/10 p-2 text-slate-200 transition hover:bg-white/20"
+                      aria-label="Отменить добавление задачи"
+                    >
+                      <FiX />
+                    </button>
+                  </form>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setIsAddingRootChild(true)}
+                    className="mt-3 inline-flex items-center gap-2 rounded-lg bg-white/15 px-3 py-2 text-sm font-medium text-white transition hover:bg-white/25"
+                  >
+                    <FiPlus /> Добавить задачу
+                  </button>
+                )}
+              </div>
+              <MindMapDropZone
+                parentId={null}
+                index={store.todos.length}
+                left={rootNode.y + dimensions.offsetY}
+                top={rootNode.x + dimensions.offsetX + DROP_ZONE_OFFSET}
+              />
+            </div>
+          )}
+
+          {otherNodes.map((node) => (
+            <MindMapNodeCard
+              key={node.data.id}
+              node={node}
+              left={node.y + dimensions.offsetY}
+              top={node.x + dimensions.offsetX}
+              offsetForDropZones={DROP_ZONE_OFFSET}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export const MindMapView = observer(MindMapViewComponent)

--- a/src/stores/TodoStore.ts
+++ b/src/stores/TodoStore.ts
@@ -15,7 +15,7 @@ interface TodoLookup {
   index: number
 }
 
-export const MAX_DEPTH = 2
+export const MAX_DEPTH = 6
 
 export class TodoStore {
   todos: TodoNode[] = []


### PR DESCRIPTION
## Summary
- extend todo hierarchy depth to seven levels and add D3 dependency
- add an interactive mind map view with drag/drop editing, completion filtering, and inline management
- expose the new mind map tab alongside the existing pinned and list views

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca9b120a3c83308a534e59a5d35b3e