### PR TITLE
Add interactive mind map view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "d3": "^7.9.0",
         "mobx": "^6.13.7",
         "mobx-react-lite": "^4.1.0",
         "react": "^19.1.1",
@@ -16,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@types/d3-hierarchy": "^3.1.7",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -1437,6 +1439,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2168,6 +2177,416 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2192,6 +2611,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2765,6 +3193,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2800,6 +3240,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -3698,6 +4147,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.50.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.2.tgz",
@@ -3762,6 +4217,18 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "d3": "^7.9.0",
     "mobx": "^6.13.7",
     "mobx-react-lite": "^4.1.0",
     "react": "^19.1.1",
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@types/d3-hierarchy": "^3.1.7",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,13 @@ import { FiPlus } from 'react-icons/fi'
 import { TodoItem } from './components/TodoItem'
 import { DropZone } from './components/DropZone'
 import { PinnedDropZone } from './components/PinnedDropZone'
+import { MindMapView } from './components/MindMapView'
 import { useTodoStore } from './stores/TodoStoreContext'
 
 const AppComponent = () => {
   const store = useTodoStore()
   const [newTitle, setNewTitle] = useState('')
-  const [activeTab, setActiveTab] = useState<'pinned' | 'all'>('pinned')
+  const [activeTab, setActiveTab] = useState<'pinned' | 'all' | 'mindmap'>('pinned')
 
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = (event) => {
     event.preventDefault()
@@ -26,7 +27,7 @@ const AppComponent = () => {
           <p className="text-sm font-medium uppercase tracking-wide text-slate-400">Задачи</p>
           <h1 className="mt-2 text-3xl font-semibold text-slate-800">Дерево задач</h1>
           <p className="mt-3 max-w-2xl text-sm text-slate-500">
-            Добавляйте задачи, группируйте их по уровням и перетаскивайте элементы, чтобы быстро управлять приоритетами. Максимальная глубина — три уровня.
+            Добавляйте задачи, группируйте их по уровням и перетаскивайте элементы, чтобы быстро управлять приоритетами. Максимальная глубина — семь уровней.
           </p>
         </header>
 
@@ -77,6 +78,18 @@ const AppComponent = () => {
               >
                 Список задач
               </button>
+              <button
+                type="button"
+                onClick={() => setActiveTab('mindmap')}
+                className={[
+                  'rounded-xl px-4 py-2 transition focus-visible:outline-none',
+                  activeTab === 'mindmap'
+                    ? 'bg-slate-900 text-white shadow-sm'
+                    : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700',
+                ].join(' ')}
+              >
+                Mind map
+              </button>
             </div>
           </div>
 
@@ -98,7 +111,7 @@ const AppComponent = () => {
                 </div>
               )}
             </>
-          ) : (
+          ) : activeTab === 'all' ? (
             <>
               <div className="space-y-3">
                 <DropZone parentId={null} depth={0} index={0} />
@@ -116,6 +129,8 @@ const AppComponent = () => {
                 </div>
               )}
             </>
+          ) : (
+            <MindMapView />
           )}
         </section>
       </div>

--- a/src/components/MindMapView.tsx
+++ b/src/components/MindMapView.tsx
@@ -1,0 +1,409 @@
+import { useState } from 'react'
+import type { DragEvent } from 'react'
+import { observer } from 'mobx-react-lite'
+import { hierarchy, tree } from 'd3-hierarchy'
+import type { HierarchyPointLink, HierarchyPointNode } from 'd3-hierarchy'
+import {
+  FiCheckSquare,
+  FiEdit2,
+  FiPlus,
+  FiSquare,
+  FiTrash2,
+} from 'react-icons/fi'
+import { useTodoStore } from '../stores/TodoStoreContext'
+import type { TodoNode } from '../stores/TodoStore'
+
+const NODE_WIDTH = 220
+const NODE_HEIGHT = 72
+const HORIZONTAL_STEP = 160
+const VERTICAL_STEP = 36
+const BRANCH_SPACING = 48
+const CENTER_NODE_ID = 'mindmap-root'
+
+type DropPreview = {
+  id: string
+  type: 'before' | 'after' | 'child'
+}
+
+type MindMapDataNode = {
+  id: string
+  title: string
+  completed: boolean
+  children: MindMapDataNode[]
+}
+
+type LayoutNode = {
+  id: string
+  data: MindMapDataNode | null
+  x: number
+  y: number
+  depth: number
+  parentId: string | null
+  isCenter?: boolean
+}
+
+type LayoutLink = {
+  sourceId: string
+  targetId: string
+}
+
+function buildMindMapNode(node: TodoNode, hideCompleted: boolean): MindMapDataNode | null {
+  const children: MindMapDataNode[] = []
+
+  for (const child of node.children) {
+    const mapped = buildMindMapNode(child, hideCompleted)
+    if (mapped) {
+      children.push(mapped)
+    }
+  }
+
+  const shouldHide =
+    hideCompleted &&
+    ((node.completed && children.length === 0) ||
+      (!node.completed && node.children.length > 0 && children.length === 0))
+
+  if (shouldHide) {
+    return null
+  }
+
+  return {
+    id: node.id,
+    title: node.title,
+    completed: node.completed,
+    children,
+  }
+}
+
+function buildMindMapData(todos: TodoNode[], hideCompleted: boolean): MindMapDataNode[] {
+  const result: MindMapDataNode[] = []
+  for (const todo of todos) {
+    const mapped = buildMindMapNode(todo, hideCompleted)
+    if (mapped) {
+      result.push(mapped)
+    }
+  }
+  return result
+}
+
+function createLayout(nodes: MindMapDataNode[]): { nodes: LayoutNode[]; links: LayoutLink[] } {
+  const layoutNodes: LayoutNode[] = []
+  const links: LayoutLink[] = []
+
+  const centerNode: LayoutNode = {
+    id: CENTER_NODE_ID,
+    data: null,
+    x: 0,
+    y: 0,
+    depth: 0,
+    parentId: null,
+    isCenter: true,
+  }
+
+  layoutNodes.push(centerNode)
+
+  let rightOffset = 0
+  let leftOffset = 0
+
+  nodes.forEach((branch, index) => {
+    const direction = index % 2 === 0 ? 1 : -1
+    const branchHierarchy = hierarchy<MindMapDataNode>(branch, (child) => child.children)
+    const branchTree = tree<MindMapDataNode>().nodeSize([NODE_HEIGHT + VERTICAL_STEP, HORIZONTAL_STEP])
+    const treeRoot = branchTree(branchHierarchy)
+
+    const descendants: HierarchyPointNode<MindMapDataNode>[] = treeRoot.descendants()
+    const minX = Math.min(...descendants.map((node) => node.x))
+    const maxX = Math.max(...descendants.map((node) => node.x))
+    const branchHeight = maxX - minX
+
+    const verticalShift = (direction === 1 ? rightOffset : leftOffset) - minX
+
+    descendants.forEach((descendant) => {
+      const layoutNode: LayoutNode = {
+        id: descendant.data.id,
+        data: descendant.data,
+        depth: descendant.depth + 1,
+        parentId: descendant.parent ? descendant.parent.data.id : CENTER_NODE_ID,
+        x: descendant.x + verticalShift,
+        y: direction * (descendant.depth + 1) * (NODE_WIDTH + HORIZONTAL_STEP * 0.5),
+      }
+
+      layoutNodes.push(layoutNode)
+    })
+
+    treeRoot.links().forEach((link: HierarchyPointLink<MindMapDataNode>) => {
+      links.push({ sourceId: link.source.data.id, targetId: link.target.data.id })
+    })
+
+    links.push({ sourceId: CENTER_NODE_ID, targetId: branch.id })
+
+    if (direction === 1) {
+      rightOffset += branchHeight + NODE_HEIGHT + BRANCH_SPACING
+    } else {
+      leftOffset += branchHeight + NODE_HEIGHT + BRANCH_SPACING
+    }
+  })
+
+  return { nodes: layoutNodes, links }
+}
+
+function getDropType(event: DragEvent<HTMLElement>): DropPreview['type'] {
+  const element = event.currentTarget as HTMLElement
+  const rect = element.getBoundingClientRect()
+  const relativeY = event.clientY - rect.top
+
+  if (relativeY < rect.height * 0.3) {
+    return 'before'
+  }
+
+  if (relativeY > rect.height * 0.7) {
+    return 'after'
+  }
+
+  return 'child'
+}
+
+export const MindMapView = observer(() => {
+  const store = useTodoStore()
+  const [hideCompleted, setHideCompleted] = useState(false)
+  const [draggingId, setDraggingId] = useState<string | null>(null)
+  const [dropPreview, setDropPreview] = useState<DropPreview | null>(null)
+
+  const rawTodos = store.todos
+  const mindMapData = buildMindMapData(rawTodos, hideCompleted)
+  const { nodes, links } = createLayout(mindMapData)
+
+  const positionMap = new Map<string, LayoutNode>()
+  nodes.forEach((node) => {
+    positionMap.set(node.id, node)
+  })
+
+  const xs = nodes.map((node) => node.x)
+  const ys = nodes.map((node) => node.y)
+
+  const minX = Math.min(...xs)
+  const maxX = Math.max(...xs)
+  const minY = Math.min(...ys)
+  const maxY = Math.max(...ys)
+
+  const padding = 120
+  const width = Math.max(600, maxY - minY + NODE_WIDTH + padding)
+  const height = Math.max(400, maxX - minX + NODE_HEIGHT + padding)
+  const offsetX = padding / 2 - minY
+  const offsetY = padding / 2 - minX
+
+  const handleAddRoot = () => {
+    const title = window.prompt('Название новой задачи')
+    if (!title) return
+    store.addTodo(null, title)
+  }
+
+  const handleAddChild = (id: string) => {
+    const title = window.prompt('Название подзадачи')
+    if (!title) return
+    store.addTodo(id, title)
+  }
+
+  const handleRename = (node: MindMapDataNode) => {
+    const title = window.prompt('Изменить название', node.title)
+    if (!title) return
+    store.updateTitle(node.id, title)
+  }
+
+  const handleToggleComplete = (id: string) => {
+    store.toggleTodo(id)
+  }
+
+  const handleDelete = (id: string) => {
+    if (!window.confirm('Удалить задачу вместе с подпунктами?')) return
+    store.deleteTodo(id)
+  }
+
+  const handleDragStart = (event: DragEvent<HTMLDivElement>, id: string) => {
+    event.stopPropagation()
+    event.dataTransfer.setData('text/plain', id)
+    event.dataTransfer.effectAllowed = 'move'
+    setDraggingId(id)
+  }
+
+  const handleDragEnd = () => {
+    setDraggingId(null)
+    setDropPreview(null)
+  }
+
+  const handleDragOverNode = (event: DragEvent<HTMLDivElement>, id: string) => {
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+
+    if (id === CENTER_NODE_ID) {
+      setDropPreview({ id, type: 'child' })
+      return
+    }
+
+    const type = getDropType(event)
+    setDropPreview({ id, type })
+  }
+
+  const handleDropOnNode = (event: DragEvent<HTMLDivElement>, id: string) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setDropPreview(null)
+
+    const draggedId = event.dataTransfer.getData('text/plain')
+    if (!draggedId || draggedId === id) return
+
+    if (id === CENTER_NODE_ID) {
+      store.moveTodo(draggedId, null, store.todos.length)
+      return
+    }
+
+    const targetInfo = store.getTodoInfo(id)
+    if (!targetInfo) return
+
+    const type = dropPreview?.id === id ? dropPreview.type : getDropType(event)
+
+    if (type === 'child') {
+      store.moveTodo(draggedId, id, targetInfo.node.children.length)
+      return
+    }
+
+    const parentId = targetInfo.parent ? targetInfo.parent.id : null
+    const index = type === 'before' ? targetInfo.index : targetInfo.index + 1
+    store.moveTodo(draggedId, parentId, index)
+  }
+
+  const hasVisibleTodos = mindMapData.length > 0
+
+  const renderNodeContent = (layoutNode: LayoutNode) => {
+    if (layoutNode.isCenter) {
+      return (
+        <div
+          className="flex h-full flex-col items-center justify-center gap-3 text-sm"
+          onDragOver={(event) => handleDragOverNode(event, CENTER_NODE_ID)}
+          onDrop={(event) => handleDropOnNode(event, CENTER_NODE_ID)}
+        >
+          <div className="rounded-full bg-slate-900 px-5 py-2 text-white shadow-lg">Mind map</div>
+          <button
+            type="button"
+            onClick={handleAddRoot}
+            className="flex items-center gap-2 rounded-full bg-emerald-500 px-4 py-2 text-xs font-medium text-white shadow-sm transition hover:bg-emerald-600"
+          >
+            <FiPlus /> Добавить задачу
+          </button>
+        </div>
+      )
+    }
+
+    if (!layoutNode.data) return null
+
+    const { data } = layoutNode
+    const isDragging = draggingId === data.id
+    const isDropTarget = dropPreview?.id === data.id
+
+    const dropHighlightClass = !isDropTarget
+      ? ''
+      : dropPreview?.type === 'child'
+        ? 'ring-2 ring-emerald-400'
+        : 'ring-2 ring-amber-400'
+
+    return (
+      <div
+        draggable
+        onDragStart={(event) => handleDragStart(event, data.id)}
+        onDragEnd={handleDragEnd}
+        onDragOver={(event) => handleDragOverNode(event, data.id)}
+        onDrop={(event) => handleDropOnNode(event, data.id)}
+        className={`flex h-full flex-col justify-between rounded-2xl bg-white/95 p-4 text-sm shadow-lg ring-1 ring-slate-200 transition ${
+          isDragging ? 'opacity-60' : ''
+        } ${dropHighlightClass}`}
+      >
+        <div className="font-medium text-slate-700">
+          <p className={data.completed ? 'text-slate-400 line-through' : undefined}>{data.title}</p>
+        </div>
+        <div className="mt-4 flex flex-wrap gap-2 text-xs text-slate-500">
+          <button
+            type="button"
+            onClick={() => handleToggleComplete(data.id)}
+            className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1.5 font-medium text-slate-600 transition hover:bg-slate-200"
+          >
+            {data.completed ? <FiCheckSquare /> : <FiSquare />} {data.completed ? 'Снять отметку' : 'Выполнено'}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleAddChild(data.id)}
+            className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2.5 py-1.5 font-medium text-emerald-600 transition hover:bg-emerald-200"
+          >
+            <FiPlus /> Подпункт
+          </button>
+          <button
+            type="button"
+            onClick={() => handleRename(data)}
+            className="inline-flex items-center gap-1 rounded-full bg-indigo-100 px-2.5 py-1.5 font-medium text-indigo-600 transition hover:bg-indigo-200"
+          >
+            <FiEdit2 /> Переименовать
+          </button>
+          <button
+            type="button"
+            onClick={() => handleDelete(data.id)}
+            className="inline-flex items-center gap-1 rounded-full bg-rose-100 px-2.5 py-1.5 font-medium text-rose-600 transition hover:bg-rose-200"
+          >
+            <FiTrash2 /> Удалить
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const renderedLinks = links
+    .map((link) => {
+      const source = positionMap.get(link.sourceId)
+      const target = positionMap.get(link.targetId)
+      if (!source || !target) return null
+
+      const sx = source.y + offsetX
+      const sy = source.x + offsetY
+      const tx = target.y + offsetX
+      const ty = target.x + offsetY
+      const mx = (sx + tx) / 2
+
+      return <path key={`${link.sourceId}-${link.targetId}`} d={`M${sx},${sy}C${mx},${sy} ${mx},${ty} ${tx},${ty}`} className="stroke-slate-300" fill="none" strokeWidth={2} />
+    })
+    .filter(Boolean)
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <label className="inline-flex items-center gap-2 text-sm text-slate-600">
+          <input
+            type="checkbox"
+            checked={hideCompleted}
+            onChange={(event) => setHideCompleted(event.target.checked)}
+            className="h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-900"
+          />
+          Скрывать выполненные подпункты
+        </label>
+      </div>
+
+      <div className="relative flex-1 overflow-auto rounded-3xl bg-gradient-to-br from-white/90 via-white to-slate-50 p-6 ring-1 ring-slate-200">
+        <svg width={width} height={height} className="block" style={{ minWidth: '100%', minHeight: '480px' }}>
+          <g>{renderedLinks}</g>
+          {nodes.map((node) => {
+            const x = node.y + offsetX - NODE_WIDTH / 2
+            const y = node.x + offsetY - NODE_HEIGHT / 2
+
+            return (
+              <foreignObject key={node.id} x={x} y={y} width={NODE_WIDTH} height={NODE_HEIGHT}>
+                {renderNodeContent(node)}
+              </foreignObject>
+            )
+          })}
+        </svg>
+
+        {!hasVisibleTodos && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-sm text-slate-400">
+            Добавьте задачи, чтобы увидеть их на карте.
+          </div>
+        )}
+      </div>
+    </div>
+  )
+})

--- a/src/stores/TodoStore.ts
+++ b/src/stores/TodoStore.ts
@@ -8,14 +8,14 @@ export interface TodoNode {
   children: TodoNode[]
 }
 
-interface TodoLookup {
+export interface TodoLookup {
   node: TodoNode
   parent: TodoNode | null
   depth: number
   index: number
 }
 
-export const MAX_DEPTH = 2
+export const MAX_DEPTH = 6
 
 export class TodoStore {
   todos: TodoNode[] = []
@@ -170,6 +170,10 @@ export class TodoStore {
     if (this.containsNode(itemInfo.node, parentId)) return false
 
     return parentInfo.depth + 1 + subtreeDepth <= MAX_DEPTH
+  }
+
+  getTodoInfo(id: string): TodoLookup | null {
+    return this.findTodo(id)
   }
 
   private createInitialTodos(): TodoNode[] {


### PR DESCRIPTION
## Summary
- raise the nesting limit to seven levels and expose todo lookup helpers required by the mind map view
- add a D3-powered mind map tab with editing, completion toggles, CRUD actions, and drag-and-drop hierarchy changes
- allow hiding completed sub-items in the mind map and add the necessary D3 dependencies

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca9b120a3c83308a534e59a5d35b3e