### PR TITLE
Add textual representation for pinned todo slots

### DIFF
--- a/src/components/PinnedTextView.tsx
+++ b/src/components/PinnedTextView.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { FiCheck, FiCopy } from 'react-icons/fi'
+
+import { formatPinnedListsToText } from '@/lib/formatPinnedText'
+import type { PinnedListView } from '@/stores/TodoStore'
+
+interface PinnedTextViewProps {
+  lists: PinnedListView[]
+}
+
+export const PinnedTextView = ({ lists }: PinnedTextViewProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const [copied, setCopied] = useState(false)
+
+  const textRepresentation = useMemo(() => formatPinnedListsToText(lists), [lists])
+  const hasContent = textRepresentation.trim().length > 0
+
+  useEffect(() => {
+    if (!copied) return
+    const timeout = window.setTimeout(() => setCopied(false), 2000)
+    return () => window.clearTimeout(timeout)
+  }, [copied])
+
+  useEffect(() => {
+    setCopied(false)
+  }, [textRepresentation])
+
+  const handleCopy = async () => {
+    if (!hasContent) return
+
+    const text = textRepresentation
+    let success = false
+
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text)
+        success = true
+      }
+    } catch (error) {
+      success = false
+    }
+
+    if (!success) {
+      const textarea = textareaRef.current
+      if (textarea) {
+        textarea.focus()
+        textarea.select()
+        try {
+          success = document.execCommand('copy')
+        } catch (error) {
+          success = false
+        }
+        window.getSelection()?.removeAllRanges()
+      }
+    }
+
+    if (success) {
+      setCopied(true)
+    }
+  }
+
+  const linesCount = textRepresentation.split('\n').length
+  const rows = Math.min(Math.max(linesCount + 2, 6), 24)
+
+  const displayValue = hasContent ? textRepresentation : 'Нет данных для отображения'
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-700">Текстовое представление</h3>
+          <p className="text-xs text-slate-500">Учитывает выбранный фильтр активности.</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={!hasContent}
+          className="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {copied ? (
+            <>
+              <FiCheck className="text-emerald-500" />
+              Скопировано
+            </>
+          ) : (
+            <>
+              <FiCopy />
+              Копировать
+            </>
+          )}
+        </button>
+      </div>
+      <textarea
+        ref={textareaRef}
+        readOnly
+        value={displayValue}
+        rows={rows}
+        className="h-auto w-full resize-none rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 font-mono text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
+      />
+    </div>
+  )
+}

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -118,11 +118,11 @@ const TodoAppContent = () => {
         <section className="flex-1 rounded-3xl bg-white/60 p-5 shadow-inner ring-1 ring-white/40">
           <div className="mb-6 flex justify-start">
             <div className="flex rounded-2xl bg-white/70 p-1 text-sm font-medium text-slate-500 shadow-sm ring-1 ring-slate-200/70">
-        {tabs.map((tab) => (
+              {tabs.map((tab) => (
                 <button
                   key={tab.key}
                   type="button"
-          onClick={() => handleSwitchTab(tab.key)}
+                  onClick={() => handleSwitchTab(tab.key)}
                   className={[
                     'rounded-xl px-4 py-2 transition focus-visible:outline-none',
                     activeTab === tab.key
@@ -146,13 +146,6 @@ const TodoAppContent = () => {
                       value={store.pinnedFilterMode}
                       onChange={(v) => store.setPinnedFilterMode(v)}
                     />
-                    <button
-                      type="button"
-                      onClick={() => setIsTextViewOpen((prev) => !prev)}
-                      className="inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-slate-400 hover:bg-white"
-                    >
-                      {isTextViewOpen ? 'Скрыть текст' : 'Текстовый вид'}
-                    </button>
                   </div>
                 </div>
                 {isAddingPinnedList ? (
@@ -171,11 +164,10 @@ const TodoAppContent = () => {
                       <button
                         type="submit"
                         disabled={!isPinnedListTitleValid}
-                        className={`rounded-lg px-3 py-2 text-sm font-medium text-white transition ${
-                          isPinnedListTitleValid
+                        className={`rounded-lg px-3 py-2 text-sm font-medium text-white transition ${isPinnedListTitleValid
                             ? 'bg-slate-900 hover:bg-slate-800'
                             : 'cursor-not-allowed bg-slate-400'
-                        }`}
+                          }`}
                       >
                         Создать
                       </button>
@@ -189,14 +181,24 @@ const TodoAppContent = () => {
                     </div>
                   </form>
                 ) : (
-                  <button
-                    type="button"
-                    onClick={() => setIsAddingPinnedList(true)}
-                    className="flex items-center gap-2 rounded-xl border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-400 hover:bg-white"
-                  >
-                    <FiPlus />
-                    Новый слот
-                  </button>
+                  <div className="flex items-center gap-3">
+                    <button
+                      type="button"
+                      onClick={() => setIsTextViewOpen((prev) => !prev)}
+                      className="inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-slate-400 hover:bg-white"
+                    >
+                      {isTextViewOpen ? 'Скрыть' : 'Текстом'}
+                    </button>
+
+                    <button
+                      type="button"
+                      onClick={() => setIsAddingPinnedList(true)}
+                      className="flex items-center gap-2 rounded-xl border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-slate-400 hover:bg-white"
+                    >
+                      <FiPlus />
+                      Новый слот
+                    </button>
+                  </div>
                 )}
               </div>
 
@@ -543,9 +545,8 @@ const SettingsTab = () => {
           type="button"
           onClick={handleExport}
           disabled={isExporting}
-          className={`mt-4 inline-flex items-center rounded-xl px-4 py-2 text-sm font-medium text-white shadow-sm transition ${
-            isExporting ? 'cursor-not-allowed bg-slate-400' : 'bg-slate-900 hover:bg-slate-800'
-          }`}
+          className={`mt-4 inline-flex items-center rounded-xl px-4 py-2 text-sm font-medium text-white shadow-sm transition ${isExporting ? 'cursor-not-allowed bg-slate-400' : 'bg-slate-900 hover:bg-slate-800'
+            }`}
         >
           {isExporting ? 'Подготовка...' : 'Скачать JSON'}
         </button>
@@ -567,9 +568,8 @@ const SettingsTab = () => {
           type="button"
           onClick={() => fileInputRef.current?.click()}
           disabled={isImporting}
-          className={`mt-4 inline-flex items-center rounded-xl px-4 py-2 text-sm font-medium text-white shadow-sm transition ${
-            isImporting ? 'cursor-not-allowed bg-slate-400' : 'bg-slate-900 hover:bg-slate-800'
-          }`}
+          className={`mt-4 inline-flex items-center rounded-xl px-4 py-2 text-sm font-medium text-white shadow-sm transition ${isImporting ? 'cursor-not-allowed bg-slate-400' : 'bg-slate-900 hover:bg-slate-800'
+            }`}
         >
           {isImporting ? 'Импорт...' : 'Выбрать файл'}
         </button>

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -10,6 +10,7 @@ import type { VisibilityMode } from '@/stores/TodoStore'
 import { TodoStoreProvider, useTodoStore } from '@/stores/TodoStoreContext'
 // мини-плейсхолдеры для сортировки больше не используются
 import { PinnedList } from './PinnedList'
+import { PinnedTextView } from './PinnedTextView'
 import { TodoItem } from './TodoItem'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
@@ -31,6 +32,7 @@ const TodoAppContent = () => {
     : 'pinned'
   const [activeTab, setActiveTab] = useState<'pinned' | 'all' | 'settings'>(normalizedTab)
   const [isAddingPinnedList, setIsAddingPinnedList] = useState(false)
+  const [isTextViewOpen, setIsTextViewOpen] = useState(false)
   const [newPinnedListTitle, setNewPinnedListTitle] = useState('')
   const pinnedListInputRef = useRef<HTMLInputElement>(null)
 
@@ -89,6 +91,9 @@ const TodoAppContent = () => {
   const handleSwitchTab = (tab: 'pinned' | 'all' | 'settings') => {
     if (tab === activeTab) return
     setActiveTab(tab)
+    if (tab !== 'pinned') {
+      setIsTextViewOpen(false)
+    }
     applyTabToUrl(tab)
   }
 
@@ -100,6 +105,9 @@ const TodoAppContent = () => {
       : 'pinned'
     if (nextTab !== activeTab) {
       setActiveTab(nextTab)
+    }
+    if (nextTab !== 'pinned') {
+      setIsTextViewOpen(false)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams])
@@ -132,11 +140,20 @@ const TodoAppContent = () => {
             <>
               <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <h2 className="text-base font-semibold text-slate-600">Слоты на день</h2>
-                <div className="flex items-center gap-2">
-                  <FilterSelect
-                    value={store.pinnedFilterMode}
-                    onChange={(v) => store.setPinnedFilterMode(v)}
-                  />
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                  <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                    <FilterSelect
+                      value={store.pinnedFilterMode}
+                      onChange={(v) => store.setPinnedFilterMode(v)}
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setIsTextViewOpen((prev) => !prev)}
+                      className="inline-flex items-center justify-center rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-slate-400 hover:bg-white"
+                    >
+                      {isTextViewOpen ? 'Скрыть текст' : 'Текстовый вид'}
+                    </button>
+                  </div>
                 </div>
                 {isAddingPinnedList ? (
                   <form
@@ -182,6 +199,12 @@ const TodoAppContent = () => {
                   </button>
                 )}
               </div>
+
+              {isTextViewOpen && (
+                <div className="mb-6">
+                  <PinnedTextView lists={pinnedLists} />
+                </div>
+              )}
 
               <div className="space-y-4">
                 {pinnedLists.map((list) => (

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -277,16 +277,28 @@ const ListContainer = observer(() => {
   const store = useTodoStore()
   const draggedId = store.draggedId
   const canAcceptRoot = draggedId !== null && store.canDrop(draggedId, null)
+  const [isOverEmpty, setIsOverEmpty] = useState(false)
+  const isRootEmpty = store.todos.length === 0
 
   const handleEmptyDragOver: React.DragEventHandler<HTMLDivElement> = (event) => {
-    if (!canAcceptRoot || store.todos.length > 0) return
+    if (!canAcceptRoot || !isRootEmpty) return
     event.preventDefault()
     event.dataTransfer.dropEffect = 'move'
+    if (!isOverEmpty) {
+      setIsOverEmpty(true)
+    }
+  }
+
+  const handleEmptyDragLeave: React.DragEventHandler<HTMLDivElement> = () => {
+    if (isOverEmpty) {
+      setIsOverEmpty(false)
+    }
   }
 
   const handleEmptyDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
-    if (!canAcceptRoot || draggedId === null || store.todos.length > 0) return
+    if (!canAcceptRoot || draggedId === null || !isRootEmpty) return
     event.preventDefault()
+    setIsOverEmpty(false)
     void store.moveTodo(draggedId, null, 0)
     store.clearDragged()
   }
@@ -295,13 +307,27 @@ const ListContainer = observer(() => {
     <div
       className="space-y-3"
       onDragOver={handleEmptyDragOver}
+      onDragLeave={handleEmptyDragLeave}
       onDrop={handleEmptyDrop}
     >
-  {store.visibleTodos.map((todo, index) => (
-        <Fragment key={todo.id}>
-          <TodoItem todo={todo} depth={0} parentId={null} index={index} />
-        </Fragment>
-      ))}
+      {isRootEmpty ? (
+        <div
+          className={[
+            'flex min-h-[120px] items-center justify-center rounded-2xl border border-dashed px-4 py-8 text-center text-sm transition-colors',
+            isOverEmpty && canAcceptRoot
+              ? 'border-emerald-300 bg-emerald-50/70 text-emerald-700'
+              : 'border-slate-200 bg-slate-50 text-slate-500',
+          ].join(' ')}
+        >
+          Добавьте первую задачу или перетащите её в этот список
+        </div>
+      ) : (
+        store.visibleTodos.map((todo, index) => (
+          <Fragment key={todo.id}>
+            <TodoItem todo={todo} depth={0} parentId={null} index={index} />
+          </Fragment>
+        ))
+      )}
     </div>
   )
 })

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -45,7 +45,7 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
   const [overPosition, setOverPosition] = useState<null | 'above' | 'below' | 'inside'>(null)
   const childInputRef = useRef<HTMLInputElement>(null)
   // Выпадающий список тегов: управляeм через общий хук
-  const tagDropdown = useDropdown({ hoverOpenDelay: 300, closeDelay: 300, animationDuration: 200, groupKey: 'tag-picker' })
+  const tagDropdown = useDropdown({ closeDelay: 1000, animationDuration: 200, groupKey: 'tag-picker', openOnHover: false })
   // Многострочное редактирование: вычисляем строки один раз при входе в режим
   const [editRows, setEditRows] = useState(1)
   const editWrapRef = useRef<HTMLDivElement>(null)

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -45,7 +45,7 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
   const [overPosition, setOverPosition] = useState<null | 'above' | 'below' | 'inside'>(null)
   const childInputRef = useRef<HTMLInputElement>(null)
   // Выпадающий список тегов: управляeм через общий хук
-  const tagDropdown = useDropdown({ closeDelay: 1000, animationDuration: 200, groupKey: 'tag-picker', openOnHover: false })
+  const tagDropdown = useDropdown({ closeDelay: 300, animationDuration: 200, groupKey: 'tag-picker', openOnHover: false })
   // Многострочное редактирование: вычисляем строки один раз при входе в режим
   const [editRows, setEditRows] = useState(1)
   const editWrapRef = useRef<HTMLDivElement>(null)

--- a/src/lib/formatPinnedText.ts
+++ b/src/lib/formatPinnedText.ts
@@ -1,0 +1,35 @@
+import type { PinnedListView } from '@/stores/TodoStore'
+
+const STATUS_COMPLETED_SYMBOL = '-'
+const STATUS_ACTIVE_SYMBOL = '+'
+
+export function formatPinnedListsToText(lists: PinnedListView[]): string {
+  if (lists.length === 0) {
+    return ''
+  }
+
+  const lines: string[] = []
+
+  lists.forEach((list, index) => {
+    lines.push(`## ${list.title}`)
+
+    if (list.todos.length > 0) {
+      lines.push('')
+      for (const todo of list.todos) {
+        const statusSymbol = todo.completed ? STATUS_COMPLETED_SYMBOL : STATUS_ACTIVE_SYMBOL
+        const tags = (todo.tags ?? [])
+          .map((tag) => tag.name.trim())
+          .filter((name) => name.length > 0)
+        const tagsPart = tags.length > 0 ? `[${tags.join(', ')}] ` : ''
+        const title = todo.title.trim()
+        lines.push(`${statusSymbol} ${tagsPart}${title}`)
+      }
+    }
+
+    if (index < lists.length - 1) {
+      lines.push('')
+    }
+  })
+
+  return lines.join('\n')
+}

--- a/src/lib/formatPinnedText.ts
+++ b/src/lib/formatPinnedText.ts
@@ -1,7 +1,7 @@
 import type { PinnedListView } from '@/stores/TodoStore'
 
-const STATUS_COMPLETED_SYMBOL = '-'
-const STATUS_ACTIVE_SYMBOL = '+'
+const STATUS_COMPLETED_SYMBOL = '+'
+const STATUS_ACTIVE_SYMBOL = '-'
 
 export function formatPinnedListsToText(lists: PinnedListView[]): string {
   if (lists.length === 0) {

--- a/src/lib/hooks/useDropdown.ts
+++ b/src/lib/hooks/useDropdown.ts
@@ -8,12 +8,13 @@ type DropdownOptions = {
   closeDelay?: number
   animationDuration?: number
   groupKey?: string
+  openOnHover?: boolean
 }
 
 type TriggerProps = {
   onClick: (e: React.MouseEvent) => void
-  onMouseEnter: (e: React.MouseEvent) => void
-  onMouseLeave: (e: React.MouseEvent) => void
+  onMouseEnter?: (e: React.MouseEvent) => void
+  onMouseLeave?: (e: React.MouseEvent) => void
   'aria-expanded': boolean
 }
 
@@ -23,7 +24,7 @@ type MenuProps = {
 }
 
 export function useDropdown(options: DropdownOptions = {}) {
-  const { hoverOpenDelay = 300, closeDelay = 300, animationDuration = 200, groupKey } = options
+  const { hoverOpenDelay = 300, closeDelay = 300, animationDuration = 200, groupKey, openOnHover = true } = options
 
   const [isMounted, setIsMounted] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
@@ -103,16 +104,17 @@ export function useDropdown(options: DropdownOptions = {}) {
   // Регистрация в группе для взаимного закрытия
   useEffect(() => {
     if (!groupKey) return
+    const id = idRef.current
     let group = DROPDOWN_GROUPS.get(groupKey)
     if (!group) {
       group = new Map()
       DROPDOWN_GROUPS.set(groupKey, group)
     }
-    group.set(idRef.current, () => close())
+    group.set(id, () => close())
     return () => {
       const g = DROPDOWN_GROUPS.get(groupKey)
       if (!g) return
-      g.delete(idRef.current)
+      g.delete(id)
       if (g.size === 0) DROPDOWN_GROUPS.delete(groupKey)
     }
   }, [close, groupKey])
@@ -125,12 +127,17 @@ export function useDropdown(options: DropdownOptions = {}) {
     }
   }, [clearCloseTimer, clearOpenHoverTimer])
 
-  const getTriggerProps = useCallback<() => TriggerProps>(() => ({
-    onClick: () => toggle(),
-    onMouseEnter: () => scheduleOpenOnHover(),
-    onMouseLeave: () => scheduleClose(),
-    'aria-expanded': isOpen,
-  }), [isOpen, scheduleClose, scheduleOpenOnHover, toggle])
+  const getTriggerProps = useCallback<() => TriggerProps>(() => {
+    const props: TriggerProps = {
+      onClick: () => toggle(),
+      onMouseLeave: () => scheduleClose(),
+      'aria-expanded': isOpen,
+    }
+    if (openOnHover) {
+      props.onMouseEnter = () => scheduleOpenOnHover()
+    }
+    return props
+  }, [isOpen, openOnHover, scheduleClose, scheduleOpenOnHover, toggle])
 
   const getMenuProps = useCallback<() => MenuProps>(() => ({
     onMouseEnter: () => clearCloseTimer(),


### PR DESCRIPTION
## Summary
- add a toggle on the slots tab that opens a text view respecting the activity filter
- implement a reusable formatter and client component that renders the textual slots view with copy-to-clipboard support

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0cbd54b708327932825e296cc2e34