### PR TITLE
feat: add textual view for pinned slots

### DIFF
--- a/src/stores/TodoStore.ts
+++ b/src/stores/TodoStore.ts
@@ -52,6 +52,37 @@ export class TodoStore {
     }))
   }
 
+  get pinnedListsText(): string {
+    const lists = this.pinnedListsWithTodos
+    if (lists.length === 0) {
+      return ''
+    }
+
+    return lists
+      .map((list, index) => {
+        const title = list.title.trim().length > 0 ? list.title : `Слот ${index + 1}`
+        const lines = list.todos.map((todo) => {
+          const statusSymbol = todo.completed ? '-' : '+'
+          const tagNames = (todo.tags ?? [])
+            .map((tag) => tag.name.trim())
+            .filter((name) => name.length > 0)
+          const parts = [statusSymbol]
+          if (tagNames.length > 0) {
+            parts.push(`[${tagNames.join(', ')}]`)
+          }
+          parts.push(todo.title)
+          return parts.join(' ')
+        })
+
+        if (lines.length === 0) {
+          return [`## ${title}`, '', 'Нет задач по текущему фильтру.'].join('\n')
+        }
+
+        return [`## ${title}`, '', ...lines].join('\n')
+      })
+      .join('\n\n')
+  }
+
   get visibleTodos(): TodoNode[] {
     return this.filterTree(this.todos, this.listFilterMode)
   }


### PR DESCRIPTION
## Summary
- add a toggle and panel to view pinned slots as formatted text and copy it
- compute textual representations of pinned slots that reuse existing activity filters

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0cbd54b708327932825e296cc2e34