### PR TITLE
Adjust tag dropdown placement

### DIFF
--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -382,7 +382,8 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
                     </button>
                     {tagDropdown.isMounted && (
                       <div
-                        className={tagDropdown.getMenuClassName('absolute right-0 z-20 mt-2 w-48 origin-top-right rounded-lg border border-slate-200 bg-white p-2 shadow-lg')}
+                        ref={tagDropdown.menuRef}
+                        className={tagDropdown.getMenuClassName('absolute right-0 z-20 w-48 rounded-lg border border-slate-200 bg-white p-2 shadow-lg')}
                         {...tagDropdown.getMenuProps()}
                       >
                         <div className="mb-2 px-1 text-xs font-medium text-slate-500">Теги</div>

--- a/src/lib/hooks/useDropdown.ts
+++ b/src/lib/hooks/useDropdown.ts
@@ -27,11 +27,37 @@ export function useDropdown(options: DropdownOptions = {}) {
 
   const [isMounted, setIsMounted] = useState(false)
   const [isOpen, setIsOpen] = useState(false)
+  const [placement, setPlacement] = useState<'bottom' | 'top'>('bottom')
 
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const menuRef = useRef<HTMLDivElement | null>(null)
   const idRef = useRef<symbol>(Symbol('dropdown'))
   const openHoverTimerRef = useRef<number | null>(null)
   const closeTimerRef = useRef<number | null>(null)
+  const menuHeightRef = useRef(0)
+
+  const updatePlacement = useCallback(() => {
+    if (typeof window === 'undefined') return
+    const root = rootRef.current
+    if (!root) return
+
+    const rootRect = root.getBoundingClientRect()
+    const menu = menuRef.current
+
+    let menuHeight = menuHeightRef.current
+    if (menu) {
+      const { height } = menu.getBoundingClientRect()
+      menuHeight = height
+      menuHeightRef.current = height
+    }
+
+    const spaceBelow = window.innerHeight - rootRect.bottom
+    const spaceAbove = rootRect.top
+    const gap = 8 // соответствие отступу mt-2/mb-2
+
+    const shouldOpenUp = spaceBelow < menuHeight + gap && spaceAbove > spaceBelow
+    setPlacement(shouldOpenUp ? 'top' : 'bottom')
+  }, [])
 
   const clearOpenHoverTimer = useCallback(() => {
     if (openHoverTimerRef.current !== null) {
@@ -60,8 +86,11 @@ export function useDropdown(options: DropdownOptions = {}) {
       }
     }
     if (!isMounted) setIsMounted(true)
-    requestAnimationFrame(() => setIsOpen(true))
-  }, [clearCloseTimer, clearOpenHoverTimer, groupKey, isMounted])
+    requestAnimationFrame(() => {
+      updatePlacement()
+      setIsOpen(true)
+    })
+  }, [clearCloseTimer, clearOpenHoverTimer, groupKey, isMounted, updatePlacement])
 
   const close = useCallback(() => {
     clearCloseTimer()
@@ -103,16 +132,17 @@ export function useDropdown(options: DropdownOptions = {}) {
   // Регистрация в группе для взаимного закрытия
   useEffect(() => {
     if (!groupKey) return
+    const dropdownId = idRef.current
     let group = DROPDOWN_GROUPS.get(groupKey)
     if (!group) {
       group = new Map()
       DROPDOWN_GROUPS.set(groupKey, group)
     }
-    group.set(idRef.current, () => close())
+    group.set(dropdownId, () => close())
     return () => {
       const g = DROPDOWN_GROUPS.get(groupKey)
       if (!g) return
-      g.delete(idRef.current)
+      g.delete(dropdownId)
       if (g.size === 0) DROPDOWN_GROUPS.delete(groupKey)
     }
   }, [close, groupKey])
@@ -138,24 +168,44 @@ export function useDropdown(options: DropdownOptions = {}) {
   }), [clearCloseTimer, scheduleClose])
 
   const getMenuClassName = useCallback((base = '') => {
+    const placementClasses =
+      placement === 'top'
+        ? 'bottom-full mb-2 origin-bottom-right'
+        : 'top-full mt-2 origin-top-right'
+    const hiddenTranslation = placement === 'top' ? 'translate-y-1' : '-translate-y-1'
     const anim = isOpen
       ? 'opacity-100 translate-y-0 scale-100 pointer-events-auto'
-      : 'opacity-0 -translate-y-1 scale-95 pointer-events-none'
+      : `opacity-0 ${hiddenTranslation} scale-95 pointer-events-none`
     const trans = 'transition-all duration-200'
-    return [base, trans, anim].filter(Boolean).join(' ')
-  }, [isOpen])
+    return [base, placementClasses, trans, anim].filter(Boolean).join(' ')
+  }, [isOpen, placement])
+
+  useEffect(() => {
+    if (!isMounted) return
+    updatePlacement()
+    if (typeof window === 'undefined') return
+    const handleRecalc = () => updatePlacement()
+    window.addEventListener('resize', handleRecalc)
+    window.addEventListener('scroll', handleRecalc, true)
+    return () => {
+      window.removeEventListener('resize', handleRecalc)
+      window.removeEventListener('scroll', handleRecalc, true)
+    }
+  }, [isMounted, updatePlacement])
 
   return useMemo(() => ({
     rootRef,
+    menuRef,
     isMounted,
     isOpen,
+    placement,
     open,
     close,
     toggle,
     getTriggerProps,
     getMenuProps,
     getMenuClassName,
-  }), [close, getMenuClassName, getMenuProps, getTriggerProps, isMounted, isOpen, open, toggle])
+  }), [close, getMenuClassName, getMenuProps, getTriggerProps, isMounted, isOpen, open, placement, toggle])
 }
 
 export type UseDropdownReturn = ReturnType<typeof useDropdown>


### PR DESCRIPTION
## Summary
- calculate dropdown placement dynamically so the tag list opens upward when near the viewport bottom
- expose the dropdown menu ref and placement-aware classes to consuming components
- wire the todo item tag picker to the new dropdown behavior

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0cdb527f4832797e97569c4485288