### PR TITLE
feat: support todo aliases

### DIFF
--- a/prisma/migrations-sqlite/20251015093000_add_alias_to_todo/migration.sql
+++ b/prisma/migrations-sqlite/20251015093000_add_alias_to_todo/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Todo" ADD COLUMN "alias" TEXT;

--- a/prisma/migrations/20251015093000_add_alias_to_todo/migration.sql
+++ b/prisma/migrations/20251015093000_add_alias_to_todo/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Todo" ADD COLUMN "alias" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Todo {
   completed Boolean  @default(false)
   completedAt DateTime?
   pinned    Boolean  @default(false)
+  alias     String?
   position  Int
   parentId  String?
   parent    Todo?    @relation("TodoChildren", fields: [parentId], references: [id], onDelete: Cascade)

--- a/src/app/api/todos/[id]/route.ts
+++ b/src/app/api/todos/[id]/route.ts
@@ -4,12 +4,13 @@ import {
   moveTodo,
   togglePinned,
   toggleTodoCompleted,
-  updateTodoTitle,
+  updateTodoDetails,
 } from '@/lib/todoService'
 
 interface PatchBody {
-  action: 'rename' | 'toggleCompleted' | 'move' | 'togglePinned'
+  action: 'rename' | 'toggleCompleted' | 'move' | 'togglePinned' | 'updateDetails'
   title?: string
+  alias?: string | null
   targetParentId?: string | null
   targetIndex?: number
 }
@@ -20,7 +21,18 @@ export async function PATCH(request: Request, { params }: { params: { id: string
 
   switch (body.action) {
     case 'rename': {
-      const state = await updateTodoTitle(id, body.title ?? '')
+      const state = await updateTodoDetails(id, { title: body.title ?? '' })
+      return NextResponse.json(state)
+    }
+    case 'updateDetails': {
+      const details: { title?: string; alias?: string | null } = {}
+      if (typeof body.title === 'string') {
+        details.title = body.title
+      }
+      if (Object.prototype.hasOwnProperty.call(body, 'alias')) {
+        details.alias = body.alias ?? null
+      }
+      const state = await updateTodoDetails(id, details)
       return NextResponse.json(state)
     }
     case 'toggleCompleted': {

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -40,6 +40,7 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
   const [isEditing, setIsEditing] = useState(false)
   const [isAddingChild, setIsAddingChild] = useState(false)
   const [titleDraft, setTitleDraft] = useState(todo.title)
+  const [aliasDraft, setAliasDraft] = useState(todo.alias ?? '')
   const [childTitle, setChildTitle] = useState('')
   const [isOverInside, setIsOverInside] = useState(false)
   const [overPosition, setOverPosition] = useState<null | 'above' | 'below' | 'inside'>(null)
@@ -87,6 +88,10 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
     setTitleDraft(todo.title)
   }, [todo.title])
 
+  useEffect(() => {
+    setAliasDraft(todo.alias ?? '')
+  }, [todo.alias])
+
   // При входе в режим редактирования определяем число строк на основе ширины поля и текущего текста
   useEffect(() => {
     if (!isEditing) return
@@ -113,9 +118,19 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
     void store.toggleTodo(todo.id)
   }
 
+  const cancelEditing = () => {
+    setTitleDraft(todo.title)
+    setAliasDraft(todo.alias ?? '')
+    setIsEditing(false)
+  }
+
   const handleEditSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
-    await store.updateTitle(todo.id, titleDraft)
+    const details: { title?: string; alias?: string | null } = { title: titleDraft }
+    if (canEditAlias) {
+      details.alias = aliasDraft
+    }
+    await store.updateTodoDetails(todo.id, details)
     setIsEditing(false)
   }
 
@@ -161,6 +176,13 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
     return true
   })
   const todoTagIds = new Set((todo.tags ?? []).map((t) => t.id))
+  const canEditAlias = useMemo(
+    () => (todo.tags ?? []).some((tag) => tag.name === 'Проект' || tag.name === 'Раздел'),
+    [todo.tags],
+  )
+  const aliasBadge = store.getNearestAlias(todo.id)
+  const aliasInputId = `todo-alias-${todo.id}`
+  const hasVisualTags = Boolean(aliasBadge) || (todo.tags?.length ?? 0) > 0
 
   const handleToggleCollapsed = () => {
     // Разрешаем сворачивать только если потенциально есть дети (или уже есть), иначе кнопка не показывается
@@ -307,14 +329,33 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
                     onBlur={recalcRows}
                     onKeyDown={(event) => {
                       if (event.key === 'Escape') {
-                        setTitleDraft(todo.title)
-                        setIsEditing(false)
+                        cancelEditing()
                       }
                     }}
                     placeholder="Название задачи"
                     rows={editRows}
                   />
                 </div>
+                {canEditAlias && (
+                  <div className="w-full sm:w-64">
+                    <label htmlFor={aliasInputId} className="mb-1 block text-xs font-medium text-slate-500">
+                      Алиас
+                    </label>
+                    <input
+                      id={aliasInputId}
+                      type="text"
+                      className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-snug text-slate-700 shadow-sm focus:border-slate-400 focus:outline-none"
+                      value={aliasDraft}
+                      onChange={(event) => setAliasDraft(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Escape') {
+                          cancelEditing()
+                        }
+                      }}
+                      placeholder="Алиас для дочерних задач"
+                    />
+                  </div>
+                )}
                 <div className="flex items-center gap-1 self-end sm:self-auto">
                   <button
                     type="submit"
@@ -325,10 +366,7 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
                   </button>
                   <button
                     type="button"
-                    onClick={() => {
-                      setTitleDraft(todo.title)
-                      setIsEditing(false)
-                    }}
+                    onClick={cancelEditing}
                     className={`${actionButtonStyles} hover:bg-slate-200`}
                     aria-label="Отменить редактирование"
                   >
@@ -347,6 +385,15 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
              ) : (
                <div className="flex flex-wrap items-start gap-2 tags-span" onDoubleClick={() => setIsEditing(true)}>
                  <p className={`${titleStyles} text-sm`}>
+                  {aliasBadge ? (
+                    <>
+                      <span className="inline-flex items-center gap-1 rounded-lg bg-slate-100 px-2 py-1 text-xs text-slate-700">
+                        {aliasBadge.alias}
+                      </span>
+                      &nbsp;
+                    </>
+                  ) : null}
+
                   {(todo.tags ?? []).map((tag) => (<>
                     <span
                       key={tag.id}
@@ -366,7 +413,7 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
                     </>
                   ))}
 
-                  {todo.tags?.length ? <>&nbsp;</> : null}
+                  {hasVisualTags ? <>&nbsp;</> : null}
 
                   <HighlightedText text={todo.title} ranges={store.getSearchHighlight(todo.id)} />
                 </p>

--- a/src/lib/todoService.ts
+++ b/src/lib/todoService.ts
@@ -13,6 +13,7 @@ interface NormalizedTodoRecord {
   title: string
   completed: boolean
   pinned: boolean
+  alias: string | null
   parentId: string | null
   position: number
 }
@@ -278,12 +279,15 @@ function normalizeTodos(
     const title = typeof raw.title === 'string' && raw.title.trim().length > 0 ? raw.title.trim() : 'Без названия'
     const completed = typeof raw.completed === 'boolean' ? raw.completed : false
     const pinned = typeof raw.pinned === 'boolean' ? raw.pinned : false
+    const aliasValue = typeof raw.alias === 'string' ? raw.alias.trim() : null
+    const alias = aliasValue && aliasValue.length > 0 ? aliasValue : null
 
     result.push({
       id,
       title,
       completed,
       pinned,
+      alias,
       parentId,
       position: index,
     })
@@ -441,6 +445,7 @@ export async function replaceTodoState(state: unknown): Promise<TodoState> {
           title: todo.title,
           completed: todo.completed,
           pinned: todo.pinned,
+          alias: todo.alias,
           parentId: todo.parentId,
           position: todo.position,
         },
@@ -553,9 +558,31 @@ export async function addTodo(parentId: string | null, title: string, tagIds?: s
   return getTodoState()
 }
 
-export async function updateTodoTitle(id: string, title: string): Promise<TodoState> {
-  const trimmed = title.trim()
-  if (!trimmed) {
+export async function updateTodoDetails(
+  id: string,
+  details: { title?: string; alias?: string | null },
+): Promise<TodoState> {
+  const data: Prisma.TodoUpdateInput = {}
+
+  if (typeof details.title === 'string') {
+    const trimmed = details.title.trim()
+    if (!trimmed) {
+      return getTodoState()
+    }
+    data.title = trimmed
+  }
+
+  if (Object.prototype.hasOwnProperty.call(details, 'alias')) {
+    const aliasValue = details.alias
+    if (typeof aliasValue === 'string') {
+      const trimmedAlias = aliasValue.trim()
+      data.alias = trimmedAlias.length === 0 ? null : trimmedAlias
+    } else {
+      data.alias = null
+    }
+  }
+
+  if (Object.keys(data).length === 0) {
     return getTodoState()
   }
 
@@ -563,10 +590,14 @@ export async function updateTodoTitle(id: string, title: string): Promise<TodoSt
 
   await prisma.todo.update({
     where: { id },
-    data: { title: trimmed },
+    data,
   })
 
   return getTodoState()
+}
+
+export async function updateTodoTitle(id: string, title: string): Promise<TodoState> {
+  return updateTodoDetails(id, { title })
 }
 
 export async function toggleTodoCompleted(id: string): Promise<TodoState> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,6 +10,7 @@ export interface Tag {
 }
 
 export interface TodoNode extends Todo {
+  alias: string | null
   children: TodoNode[]
   tags?: Tag[]
 }

--- a/src/stores/TodoStore.ts
+++ b/src/stores/TodoStore.ts
@@ -119,11 +119,27 @@ export class TodoStore {
     })
   }
 
-  async updateTitle(id: string, title: string) {
-    if (!title.trim()) return
+  async updateTodoDetails(id: string, details: { title?: string; alias?: string | null }) {
+    const payload: Record<string, unknown> = { action: 'updateDetails' }
+    let hasChanges = false
+
+    if (typeof details.title === 'string') {
+      const trimmed = details.title.trim()
+      if (!trimmed) return
+      payload.title = trimmed
+      hasChanges = true
+    }
+
+    if (Object.prototype.hasOwnProperty.call(details, 'alias')) {
+      payload.alias = details.alias
+      hasChanges = true
+    }
+
+    if (!hasChanges) return
+
     await this.mutate(`/api/todos/${id}`, {
       method: 'PATCH',
-      body: JSON.stringify({ action: 'rename', title }),
+      body: JSON.stringify(payload),
     })
   }
 
@@ -383,6 +399,27 @@ export class TodoStore {
       method: 'DELETE',
       body: JSON.stringify({ tagId }),
     })
+  }
+
+  getNearestAlias(todoId: string): { todoId: string; alias: string } | null {
+    const info = this.findTodo(todoId)
+    if (!info) return null
+
+    let currentParent = info.parent
+    while (currentParent) {
+      const aliasValue = typeof currentParent.alias === 'string' ? currentParent.alias.trim() : ''
+      const hasAlias = aliasValue.length > 0
+      const hasRequiredTag = (currentParent.tags ?? []).some((tag) => tag.name === 'Проект' || tag.name === 'Раздел')
+
+      if (hasAlias && hasRequiredTag) {
+        return { todoId: currentParent.id, alias: aliasValue }
+      }
+
+      const parentInfo = this.findTodo(currentParent.id)
+      currentParent = parentInfo?.parent ?? null
+    }
+
+    return null
   }
 
   async reorderTags(tagIds: string[]) {


### PR DESCRIPTION
## Summary
- add an alias column for todos and create matching migrations for both databases
- allow updating todo aliases via the API and state store while validating edits in the UI
- render ancestor aliases as read-only tags on child todos and expose an input for editing when applicable

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ea47de2e848324b8df91996db2f186