### PR TITLE
feat: add keyboard navigation and todo hotkeys

### DIFF
--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ChangeEventHandler, FormEventHandler } from 'react'
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { observer } from 'mobx-react-lite'
 import { FiPlus } from 'react-icons/fi'
 import type { TodoState } from '@/lib/types'
@@ -40,14 +40,25 @@ const TodoAppContent = () => {
   const [newPinnedListTitle, setNewPinnedListTitle] = useState('')
   const pinnedListInputRef = useRef<HTMLInputElement>(null)
 
-  const handleAdd = async () => {
+  const closeAddModal = useCallback(() => {
+    setIsAddModalOpen(false)
+    setTimeout(() => setIsAddModalMounted(false), 200)
+  }, [])
+
+  const openAddModal = useCallback(() => {
+    setIsAddModalMounted(true)
+    setSelectedTagIds([])
+    requestAnimationFrame(() => setIsAddModalOpen(true))
+  }, [])
+
+  const handleAdd = useCallback(async () => {
     const trimmed = newTitle.trim()
     if (!trimmed) return
     await store.addTodo(null, trimmed, selectedTagIds)
     setNewTitle('')
     setSelectedTagIds([])
     closeAddModal()
-  }
+  }, [closeAddModal, newTitle, selectedTagIds, store])
 
   const handlePinnedListSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
@@ -86,19 +97,7 @@ const TodoAppContent = () => {
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [isAddModalOpen, newTitle])
-
-  const openAddModal = () => {
-    setIsAddModalMounted(true)
-    setSelectedTagIds([])
-    // next tick to trigger transition
-    requestAnimationFrame(() => setIsAddModalOpen(true))
-  }
-
-  const closeAddModal = () => {
-    setIsAddModalOpen(false)
-    setTimeout(() => setIsAddModalMounted(false), 200)
-  }
+  }, [closeAddModal, handleAdd, isAddModalOpen])
 
   const tabs: { key: 'pinned' | 'all' | 'settings'; label: string }[] = useMemo(
     () => [
@@ -110,21 +109,37 @@ const TodoAppContent = () => {
   )
 
   // Синхронизация URL при смене вкладки пользователем
-  const applyTabToUrl = (tab: 'pinned' | 'all' | 'settings') => {
+  const applyTabToUrl = useCallback((tab: 'pinned' | 'all' | 'settings') => {
     const params = new URLSearchParams(searchParams)
     params.set('tab', tab)
     const next = `${pathname}?${params.toString()}`
     router.replace(next, { scroll: false })
-  }
+  }, [pathname, router, searchParams])
 
-  const handleSwitchTab = (tab: 'pinned' | 'all' | 'settings') => {
+  const handleSwitchTab = useCallback((tab: 'pinned' | 'all' | 'settings') => {
     if (tab === activeTab) return
     setActiveTab(tab)
     if (tab !== 'pinned') {
       setIsTextViewOpen(false)
     }
+    if (tab === 'settings') {
+      store.setFocusedTodoId(null)
+    } else if (tab === 'pinned') {
+      if (!store.isTodoVisibleInScope(store.focusedTodoId, 'pinned')) {
+        store.focusFirstTodo('pinned')
+      } else if (store.focusedTodoId) {
+        const listId = store.findPinnedListIdForTodo(store.focusedTodoId)
+        if (listId && !store.isActivePinnedList(listId)) {
+          void store.setActivePinnedList(listId)
+        }
+      }
+    } else {
+      if (!store.isTodoVisibleInScope(store.focusedTodoId, 'list')) {
+        store.focusFirstTodo('list')
+      }
+    }
     applyTabToUrl(tab)
-  }
+  }, [activeTab, applyTabToUrl, store])
 
   // Обратная синхронизация: если URL поменялся (например, навигация назад/вперёд), обновим стейт
   useEffect(() => {
@@ -140,6 +155,151 @@ const TodoAppContent = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams])
+
+  useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null) => {
+      if (!(target instanceof HTMLElement)) return false
+      if (target.isContentEditable) return true
+      const tagName = target.tagName
+      return tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT'
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return
+
+      if ((event.ctrlKey || event.metaKey) && !event.shiftKey && !event.altKey) {
+        if (event.key === '1') {
+          event.preventDefault()
+          handleSwitchTab('pinned')
+          return
+        }
+        if (event.key === '2') {
+          event.preventDefault()
+          handleSwitchTab('all')
+          return
+        }
+        if (event.key === '3') {
+          event.preventDefault()
+          handleSwitchTab('settings')
+          return
+        }
+      }
+
+      if (isEditableTarget(event.target)) return
+      if (isAddModalOpen) return
+      if (activeTab === 'settings') return
+
+      const scope = activeTab === 'pinned' ? 'pinned' : 'list'
+      const focusedId = store.focusedTodoId
+
+      switch (event.key) {
+        case 'ArrowDown': {
+          const moved = store.focusNextTodo(1, scope)
+          if (moved) event.preventDefault()
+          return
+        }
+        case 'ArrowUp': {
+          const moved = store.focusNextTodo(-1, scope)
+          if (moved) event.preventDefault()
+          return
+        }
+        case 'ArrowLeft': {
+          if (activeTab === 'pinned') {
+            const prevList = store.getAdjacentPinnedListId(-1)
+            if (prevList) {
+              event.preventDefault()
+              void store.setActivePinnedList(prevList)
+              store.focusFirstTodoInPinnedList(prevList)
+            }
+            return
+          }
+          if (!focusedId) return
+          const info = store.findTodo(focusedId)
+          if (!info) return
+          if (!store.isSearchActive && info.node.children.length > 0 && !store.isCollapsed(focusedId)) {
+            event.preventDefault()
+            store.setCollapsed(focusedId, true)
+            return
+          }
+          if (info.parent) {
+            event.preventDefault()
+            store.focusParentTodo(focusedId)
+          }
+          return
+        }
+        case 'ArrowRight': {
+          if (activeTab === 'pinned') {
+            const nextList = store.getAdjacentPinnedListId(1)
+            if (nextList) {
+              event.preventDefault()
+              void store.setActivePinnedList(nextList)
+              store.focusFirstTodoInPinnedList(nextList)
+            }
+            return
+          }
+          if (!focusedId) return
+          const info = store.findTodo(focusedId)
+          if (!info) return
+          if (!store.isSearchActive && info.node.children.length > 0 && store.isCollapsed(focusedId)) {
+            event.preventDefault()
+            store.setCollapsed(focusedId, false)
+            return
+          }
+          if (info.node.children.length > 0) {
+            event.preventDefault()
+            store.focusFirstChildTodo(focusedId)
+          }
+          return
+        }
+        case 'Delete': {
+          if (focusedId) {
+            event.preventDefault()
+            void store.deleteTodo(focusedId)
+          }
+          return
+        }
+        case 'F2': {
+          if (focusedId) {
+            event.preventDefault()
+            store.requestKeyboardAction('edit', focusedId)
+          }
+          return
+        }
+        default:
+          break
+      }
+
+      if (event.key === 'Backspace' && focusedId && event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        event.preventDefault()
+        void store.deleteTodo(focusedId)
+        return
+      }
+
+      if (event.key.toLowerCase() === 'a' && activeTab === 'all' && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        event.preventDefault()
+        openAddModal()
+        return
+      }
+
+      if (event.key.toLowerCase() === 'e' && focusedId && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        event.preventDefault()
+        store.requestKeyboardAction('edit', focusedId)
+        return
+      }
+
+      if (event.key.toLowerCase() === 't' && focusedId && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        event.preventDefault()
+        if (event.shiftKey) {
+          void store.detachLastTag(focusedId)
+        } else {
+          store.requestKeyboardAction('openTags', focusedId)
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [activeTab, handleSwitchTab, isAddModalOpen, openAddModal, store])
 
   return (
     <div className="min-h-screen bg-canvas-light text-slate-900">

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -50,6 +50,7 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
   const [editRows, setEditRows] = useState(1)
   const editWrapRef = useRef<HTMLDivElement>(null)
   const measureRef = useRef<HTMLDivElement>(null)
+  const cardRef = useRef<HTMLDivElement>(null)
 
   // Общая функция измерения требуемого количества строк.
   const recalcRows = () => {
@@ -82,6 +83,7 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
   const canReorderInTree = draggedId !== null && store.canDrop(draggedId, parentId)
   const isPinnedContext = Boolean(pinnedListId)
   const canReorderInPinned = draggedId !== null && isPinnedContext && store.isPinned(draggedId!)
+  const isFocused = store.focusedTodoId === todo.id
 
   useEffect(() => {
     setTitleDraft(todo.title)
@@ -106,6 +108,18 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
     }
   }, [isAddingChild])
 
+  useEffect(() => {
+    if (!isFocused || isEditing || isAddingChild) return
+    const element = cardRef.current
+    if (!element) return
+    if (document.activeElement !== element) {
+      element.focus({ preventScroll: true })
+    }
+    if (typeof element.scrollIntoView === 'function') {
+      element.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+    }
+  }, [isAddingChild, isEditing, isFocused])
+
   // Привязываем ref корня выпадушки для клика-вне
   const tagPickerRef = tagDropdown.rootRef
 
@@ -113,10 +127,14 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
     void store.toggleTodo(todo.id)
   }
 
-  const handleEditSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
-    event.preventDefault()
+  const commitEdit = async () => {
     await store.updateTitle(todo.id, titleDraft)
     setIsEditing(false)
+  }
+
+  const handleEditSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
+    event.preventDefault()
+    await commitEdit()
   }
 
   const handleAddChild: React.FormEventHandler<HTMLFormElement> = async (event) => {
@@ -161,6 +179,31 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
     return true
   })
   const todoTagIds = new Set((todo.tags ?? []).map((t) => t.id))
+
+  useEffect(() => {
+    const action = store.keyboardAction
+    if (!action || action.targetId !== todo.id) return
+
+    if (action.type === 'edit') {
+      setIsEditing(true)
+      store.clearKeyboardAction(action.token)
+      return
+    }
+
+    if (action.type === 'openTags') {
+      if (availableTags.length === 0) {
+        store.clearKeyboardAction(action.token)
+        return
+      }
+      tagDropdown.open()
+      window.setTimeout(() => {
+        const root = tagPickerRef.current
+        const firstButton = root?.querySelector<HTMLButtonElement>('button[role="menuitemcheckbox"]')
+        firstButton?.focus()
+      }, 0)
+      store.clearKeyboardAction(action.token)
+    }
+  }, [availableTags.length, store, tagDropdown, todo.id, tagPickerRef])
 
   const handleToggleCollapsed = () => {
     // Разрешаем сворачивать только если потенциально есть дети (или уже есть), иначе кнопка не показывается
@@ -251,13 +294,21 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
   return (
     <div className="space-y-1">
       <div
+        ref={cardRef}
+        tabIndex={isEditing ? -1 : 0}
+        onFocus={() => store.focusTodo(todo.id, isPinnedContext ? 'pinned' : 'list')}
+        onMouseDown={() => store.focusTodo(todo.id, isPinnedContext ? 'pinned' : 'list')}
         className={[
-          'group/todo rounded-xl bg-white/95 ring-1 ring-slate-200 transition-all duration-200 hover:shadow-md',
+          'group/todo rounded-xl bg-white/95 ring-1 ring-slate-200 transition-all duration-200 hover:shadow-md focus:outline-none focus-visible:outline-none',
           isDragging ? 'opacity-60 ring-2 ring-slate-300' : '',
           isOverInside && canDropInside ? 'ring-2 ring-emerald-400/80 bg-emerald-50/50' : '',
           overPosition === 'above' ? 'shadow-[inset_0_2px_0_0_rgba(16,185,129,0.7)]' : '',
           overPosition === 'below' ? 'shadow-[inset_0_-2px_0_0_rgba(16,185,129,0.7)]' : '',
+          isFocused && !(isOverInside && canDropInside) && !isDragging
+            ? 'ring-2 ring-emerald-400 ring-offset-2 ring-offset-white shadow-md'
+            : '',
         ].join(' ')}
+        aria-selected={isFocused}
         draggable={!isEditing && !isAddingChild}
         onDragStart={handleDragStart}
         onDragEnd={handleDragEnd}
@@ -309,6 +360,22 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
                       if (event.key === 'Escape') {
                         setTitleDraft(todo.title)
                         setIsEditing(false)
+                        return
+                      }
+                      if ((event.key === 'Enter' && (event.ctrlKey || event.metaKey))) {
+                        event.preventDefault()
+                        void commitEdit()
+                        return
+                      }
+                      if (
+                        event.key === 'Enter'
+                        && !event.shiftKey
+                        && !event.ctrlKey
+                        && !event.metaKey
+                        && editRows <= 1
+                      ) {
+                        event.preventDefault()
+                        void commitEdit()
                       }
                     }}
                     placeholder="Название задачи"
@@ -481,6 +548,13 @@ const TodoItemComponent = ({ todo, depth, parentId, index, pinnedListId, allowCh
               className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 shadow-inner focus:border-slate-400 focus:outline-none"
               value={childTitle}
               onChange={(event) => setChildTitle(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Escape') {
+                  event.preventDefault()
+                  setChildTitle('')
+                  setIsAddingChild(false)
+                }
+              }}
               placeholder="Новая подзадача"
             />
             <div className="flex items-center gap-1">

--- a/src/stores/TodoStore.ts
+++ b/src/stores/TodoStore.ts
@@ -23,6 +23,21 @@ interface ListViewResult {
   highlightMap: Map<string, SearchHighlight>
 }
 
+type FocusScope = 'list' | 'pinned'
+
+type KeyboardActionType = 'edit' | 'openTags'
+
+interface KeyboardAction {
+  type: KeyboardActionType
+  targetId: string
+  token: number
+}
+
+interface PinnedTodoRef {
+  todoId: string
+  listId: string
+}
+
 export class TodoStore {
   todos: TodoNode[] = []
   pinnedLists: PinnedListState[] = []
@@ -32,6 +47,7 @@ export class TodoStore {
   collapsedIds: Set<string> = new Set()
   // Set со свернутыми закрепленными слотами (хранит id списков)
   collapsedPinnedListIds: Set<string> = new Set()
+  focusedTodoId: string | null = null
 
   // Видимость выполненных задач
   listFilterMode: VisibilityMode = 'today'
@@ -40,6 +56,9 @@ export class TodoStore {
   // Поиск и фильтрация по тегам в основном списке
   searchQuery = ''
   searchTagIds: string[] = []
+
+  keyboardAction: KeyboardAction | null = null
+  private actionToken = 0
 
   private static readonly COLLAPSE_STORAGE_KEY = 'todoCollapsedIds_v1'
   private static readonly PINNED_COLLAPSE_STORAGE_KEY = 'pinnedCollapsedIds_v1'
@@ -70,6 +89,21 @@ export class TodoStore {
     return this.listView.todos
   }
 
+  get linearVisibleTodoIds(): string[] {
+    const result: string[] = []
+    const traverse = (nodes: TodoNode[]) => {
+      for (const node of nodes) {
+        result.push(node.id)
+        const collapsed = !this.isSearchActive && this.isCollapsed(node.id)
+        if (!collapsed && node.children.length > 0) {
+          traverse(node.children)
+        }
+      }
+    }
+    traverse(this.visibleTodos)
+    return result
+  }
+
   get listView(): ListViewResult {
     const byMode = this.filterTreeByMode(this.todos, this.listFilterMode)
     if (!this.isSearchActive) {
@@ -83,6 +117,22 @@ export class TodoStore {
 
   get isSearchActive(): boolean {
     return this.searchQuery.trim().length > 0 || this.searchTagIds.length > 0
+  }
+
+  get pinnedTodoRefs(): PinnedTodoRef[] {
+    const result: PinnedTodoRef[] = []
+    for (const list of this.pinnedListsWithTodos) {
+      for (const todo of list.todos) {
+        result.push({ todoId: todo.id, listId: list.id })
+      }
+    }
+    return result
+  }
+
+  get activePinnedListId(): string | null {
+    const active = this.pinnedLists.find((list) => list.isActive)
+    if (active) return active.id
+    return this.pinnedLists[0]?.id ?? null
   }
 
   get selectedSearchTags(): Tag[] {
@@ -136,6 +186,134 @@ export class TodoStore {
 
   async deleteTodo(id: string) {
     await this.mutate(`/api/todos/${id}`, { method: 'DELETE' })
+  }
+
+  setFocusedTodoId(id: string | null) {
+    this.focusedTodoId = id
+  }
+
+  focusTodo(id: string | null, scope: FocusScope) {
+    this.focusedTodoId = id
+    if (scope === 'pinned' && id) {
+      const listId = this.findPinnedListIdForTodo(id)
+      if (listId && !this.isActivePinnedList(listId)) {
+        void this.setActivePinnedList(listId)
+      }
+    }
+  }
+
+  focusFirstTodo(scope: FocusScope): string | null {
+    if (scope === 'list') {
+      const sequence = this.linearVisibleTodoIds
+      if (sequence.length === 0) {
+        this.focusedTodoId = null
+        return null
+      }
+      const firstId = sequence[0]
+      this.focusTodo(firstId, 'list')
+      return firstId
+    }
+
+    const refs = this.pinnedTodoRefs
+    if (refs.length === 0) {
+      this.focusedTodoId = null
+      return null
+    }
+    const first = refs[0]
+    this.focusTodo(first.todoId, 'pinned')
+    return first.todoId
+  }
+
+  focusFirstTodoInPinnedList(listId: string): string | null {
+    const list = this.pinnedListsWithTodos.find((item) => item.id === listId)
+    const firstId = list?.todos[0]?.id ?? null
+    if (firstId) {
+      this.focusTodo(firstId, 'pinned')
+    } else {
+      this.focusedTodoId = null
+    }
+    return firstId
+  }
+
+  isTodoVisibleInScope(id: string | null, scope: FocusScope): boolean {
+    if (!id) return false
+    if (scope === 'list') {
+      return this.linearVisibleTodoIds.includes(id)
+    }
+    return this.pinnedTodoRefs.some((ref) => ref.todoId === id)
+  }
+
+  focusNextTodo(direction: 1 | -1, scope: FocusScope): string | null {
+    if (scope === 'list') {
+      const sequence = this.linearVisibleTodoIds
+      if (sequence.length === 0) return null
+      const currentIndex = this.focusedTodoId ? sequence.indexOf(this.focusedTodoId) : -1
+      let nextIndex = currentIndex + direction
+      if (currentIndex === -1) {
+        nextIndex = direction > 0 ? 0 : sequence.length - 1
+      }
+      if (nextIndex < 0 || nextIndex >= sequence.length) return null
+      const nextId = sequence[nextIndex]
+      this.focusTodo(nextId, 'list')
+      return nextId
+    }
+
+    const refs = this.pinnedTodoRefs
+    if (refs.length === 0) return null
+    const currentIndex = this.focusedTodoId
+      ? refs.findIndex((ref) => ref.todoId === this.focusedTodoId)
+      : -1
+    let nextIndex = currentIndex + direction
+    if (currentIndex === -1) {
+      nextIndex = direction > 0 ? 0 : refs.length - 1
+    }
+    if (nextIndex < 0 || nextIndex >= refs.length) return null
+    const nextRef = refs[nextIndex]
+    this.focusTodo(nextRef.todoId, 'pinned')
+    return nextRef.todoId
+  }
+
+  focusParentTodo(id: string): string | null {
+    const info = this.findTodo(id)
+    if (!info?.parent) return null
+    this.focusTodo(info.parent.id, 'list')
+    return info.parent.id
+  }
+
+  focusFirstChildTodo(id: string): string | null {
+    const info = this.findTodo(id)
+    if (!info || info.node.children.length === 0) return null
+    const firstChild = info.node.children[0]
+    this.focusTodo(firstChild.id, 'list')
+    return firstChild.id
+  }
+
+  getAdjacentPinnedListId(direction: 1 | -1): string | null {
+    if (this.pinnedLists.length === 0) return null
+    let index = this.pinnedLists.findIndex((list) => list.isActive)
+    if (index === -1) index = 0
+    const nextIndex = index + direction
+    if (nextIndex < 0 || nextIndex >= this.pinnedLists.length) return null
+    return this.pinnedLists[nextIndex].id
+  }
+
+  requestKeyboardAction(type: KeyboardActionType, targetId: string) {
+    this.actionToken += 1
+    this.keyboardAction = { type, targetId, token: this.actionToken }
+  }
+
+  clearKeyboardAction(token: number) {
+    if (this.keyboardAction?.token === token) {
+      this.keyboardAction = null
+    }
+  }
+
+  async detachLastTag(todoId: string) {
+    const info = this.findTodo(todoId)
+    const tags = info?.node.tags ?? []
+    if (tags.length === 0) return
+    const last = tags[tags.length - 1]
+    await this.detachTag(todoId, last.id)
   }
 
   setDragged(id: string | null) {
@@ -471,6 +649,15 @@ export class TodoStore {
       }
     }
 
+    return null
+  }
+
+  findPinnedListIdForTodo(todoId: string): string | null {
+    for (const ref of this.pinnedTodoRefs) {
+      if (ref.todoId === todoId) {
+        return ref.listId
+      }
+    }
     return null
   }
 


### PR DESCRIPTION
## Summary
- add global keyboard shortcuts for navigation, tab switching, and todo actions
- track focused todos and expose focus helpers in the store to drive keyboard UX
- update todo item UI to react to keyboard focus, open the tag picker, and refine editing key handling

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ea497de9dc8324bff0e5c33ef032b4