### PR TITLE
Add Telegram authentication and user-scoped data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,15 @@ DATABASE_URL="file:./dev.db"
 # - Если нужна только синхронизация без миграций: используйте pnpm db:push (обычно только в dev c SQLite).
 # - Для CI/CD: используйте prisma migrate deploy с PostgreSQL.
 
+
+############################################################
+# TELEGRAM AUTHENTICATION
+############################################################
+# Токен Telegram-бота для верификации данных входа.
+TELEGRAM_BOT_TOKEN="123456789:ABCDEF_your_bot_token"
+
+# Юзернейм бота (без @), доступен на клиенте для виджета входа.
+NEXT_PUBLIC_TELEGRAM_BOT_USERNAME="your_bot_username"
+
+# Максимальный возраст данных авторизации в секундах (опционально, по умолчанию 86400).
+# TELEGRAM_AUTH_MAX_AGE=86400

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,7 @@
 # Локальная БД разработки (SQLite)
 DATABASE_URL="file:./dev.db"
+
+# Telegram auth (укажите реальные значения при необходимости)
+# TELEGRAM_BOT_TOKEN="123456789:ABCDEF_your_bot_token"
+# NEXT_PUBLIC_TELEGRAM_BOT_USERNAME="your_bot_username"
+# TELEGRAM_AUTH_MAX_AGE=86400

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,10 +26,12 @@ model Todo {
   pinned    Boolean  @default(false)
   position  Int
   parentId  String?
+  userId    String
   parent    Todo?    @relation("TodoChildren", fields: [parentId], references: [id], onDelete: Cascade)
   children  Todo[]   @relation("TodoChildren")
   pinnedIn  PinnedTodo[]
   tags      Tag[]
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 }
@@ -40,7 +42,9 @@ model PinnedList {
   position  Int
   isPrimary Boolean      @default(false)
   isActive  Boolean      @default(false)
+  userId    String
   todos     PinnedTodo[]
+  user      User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt DateTime     @default(now())
   updatedAt DateTime     @updatedAt
 }
@@ -64,6 +68,34 @@ model Tag {
   position  Int      @default(0)
   isSystem  Boolean  @default(false)
   todos     Todo[]
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+}
+
+model User {
+  id         String    @id @default(cuid())
+  telegramId String    @unique
+  firstName  String
+  lastName   String?
+  username   String?
+  photoUrl   String?
+  todos      Todo[]
+  pinnedLists PinnedList[]
+  tags       Tag[]
+  sessions   Session[]
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+}
+
+model Session {
+  id        String   @id @default(cuid())
+  token     String   @unique
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+  expiresAt DateTime
+
+  @@index([userId])
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import { buildClearedSessionCookie, getSessionFromCookies, invalidateSession } from '@/lib/auth/session'
+import type { TodoState } from '@/lib/types'
+
+const EMPTY_STATE: TodoState = {
+  todos: [],
+  pinnedLists: [],
+  tags: [],
+  user: null,
+}
+
+export async function POST() {
+  const session = await getSessionFromCookies()
+  if (session) {
+    await invalidateSession(session.token)
+  }
+
+  const response = NextResponse.json(EMPTY_STATE)
+  response.cookies.set(buildClearedSessionCookie())
+  return response
+}

--- a/src/app/api/auth/telegram/route.ts
+++ b/src/app/api/auth/telegram/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+import { verifyTelegramAuth, type TelegramAuthPayload } from '@/lib/auth/telegram'
+import { buildSessionCookie, createSession } from '@/lib/auth/session'
+import { prisma } from '@/lib/prisma'
+import { getTodoStateForUser } from '@/lib/todoService'
+
+export async function POST(request: Request) {
+  try {
+    const payload = (await request.json()) as TelegramAuthPayload
+    const data = verifyTelegramAuth(payload)
+
+    const user = await prisma.user.upsert({
+      where: { telegramId: data.telegramId },
+      update: {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        username: data.username,
+        photoUrl: data.photoUrl,
+      },
+      create: {
+        telegramId: data.telegramId,
+        firstName: data.firstName,
+        lastName: data.lastName,
+        username: data.username,
+        photoUrl: data.photoUrl,
+      },
+    })
+
+    const session = await createSession(user.id)
+    const state = await getTodoStateForUser(user.id)
+    const response = NextResponse.json(state)
+    response.cookies.set(buildSessionCookie(session.token, session.expiresAt))
+    return response
+  } catch (error) {
+    console.error('Telegram authentication failed', error)
+    const message = error instanceof Error ? error.message : 'Не удалось авторизоваться'
+    return NextResponse.json({ message }, { status: 400 })
+  }
+}

--- a/src/app/api/pinned-lists/[id]/route.ts
+++ b/src/app/api/pinned-lists/[id]/route.ts
@@ -1,18 +1,37 @@
 import { NextResponse } from 'next/server'
 import { deletePinnedList, renamePinnedList, setActivePinnedList } from '@/lib/todoService'
+import { requireUser, UnauthorizedError } from '@/lib/auth/session'
 
 export async function PATCH(request: Request, { params }: { params: { id: string } }) {
-  const body = await request.json()
-  if (body && typeof body === 'object' && body.action === 'setActive') {
-    const state = await setActivePinnedList(params.id)
+  try {
+    const user = await requireUser()
+    const body = await request.json()
+    if (body && typeof body === 'object' && body.action === 'setActive') {
+      const state = await setActivePinnedList(user.id, params.id)
+      return NextResponse.json(state)
+    }
+    const title = (body?.title as string) ?? ''
+    const state = await renamePinnedList(user.id, params.id, title)
     return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to update pinned list', error)
+    return NextResponse.json({ message: 'Не удалось обновить список' }, { status: 400 })
   }
-  const title = (body?.title as string) ?? ''
-  const state = await renamePinnedList(params.id, title)
-  return NextResponse.json(state)
 }
 
 export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
-  const state = await deletePinnedList(params.id)
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const state = await deletePinnedList(user.id, params.id)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to delete pinned list', error)
+    return NextResponse.json({ message: 'Не удалось удалить список' }, { status: 400 })
+  }
 }

--- a/src/app/api/pinned-lists/move/route.ts
+++ b/src/app/api/pinned-lists/move/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { movePinnedTodo } from '@/lib/todoService'
+import { requireUser, UnauthorizedError } from '@/lib/auth/session'
 
 interface Body {
   todoId: string
@@ -8,7 +9,16 @@ interface Body {
 }
 
 export async function POST(request: Request) {
-  const { todoId, targetListId, targetIndex } = (await request.json()) as Body
-  const state = await movePinnedTodo(todoId, targetListId, targetIndex)
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { todoId, targetListId, targetIndex } = (await request.json()) as Body
+    const state = await movePinnedTodo(user.id, todoId, targetListId, targetIndex)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to move pinned todo', error)
+    return NextResponse.json({ message: 'Не удалось переместить задачу' }, { status: 400 })
+  }
 }

--- a/src/app/api/pinned-lists/route.ts
+++ b/src/app/api/pinned-lists/route.ts
@@ -1,13 +1,31 @@
 import { NextResponse } from 'next/server'
-import { addPinnedList, getTodoState } from '@/lib/todoService'
+import { addPinnedList, getTodoStateForUser } from '@/lib/todoService'
+import { requireUser, UnauthorizedError } from '@/lib/auth/session'
 
 export async function GET() {
-  const state = await getTodoState()
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const state = await getTodoStateForUser(user.id)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    throw error
+  }
 }
 
 export async function POST(request: Request) {
-  const { title } = await request.json()
-  const state = await addPinnedList(title ?? '')
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { title } = await request.json()
+    const state = await addPinnedList(user.id, title ?? '')
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to add pinned list', error)
+    return NextResponse.json({ message: 'Не удалось добавить список' }, { status: 400 })
+  }
 }

--- a/src/app/api/state/route.ts
+++ b/src/app/api/state/route.ts
@@ -1,17 +1,30 @@
 import { NextResponse } from 'next/server'
-import { getTodoState, replaceTodoState } from '@/lib/todoService'
+import { getTodoStateForUser, replaceTodoState } from '@/lib/todoService'
+import { requireUser, UnauthorizedError } from '@/lib/auth/session'
 
 export async function GET() {
-  const state = await getTodoState()
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const state = await getTodoStateForUser(user.id)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    throw error
+  }
 }
 
 export async function POST(request: Request) {
   try {
+    const user = await requireUser()
     const payload = await request.json()
-    const state = await replaceTodoState(payload)
+    const state = await replaceTodoState(user.id, payload)
     return NextResponse.json(state)
   } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
     console.error('Failed to import todo state', error)
     return NextResponse.json(
       { message: 'Не удалось импортировать данные. Проверьте содержимое файла.' },

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -1,31 +1,76 @@
 import { NextResponse } from 'next/server'
 import { addTag, deleteTag, listTags, renameTag, reorderTags } from '@/lib/todoService'
+import { requireUser, UnauthorizedError } from '@/lib/auth/session'
 
 export async function GET() {
-  const state = await listTags()
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const state = await listTags(user.id)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    throw error
+  }
 }
 
 export async function POST(request: Request) {
-  const { name } = await request.json()
-  const state = await addTag(name ?? '')
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { name } = await request.json()
+    const state = await addTag(user.id, name ?? '')
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to add tag', error)
+    return NextResponse.json({ message: 'Не удалось добавить тег' }, { status: 400 })
+  }
 }
 
 export async function PATCH(request: Request) {
-  const { id, name } = await request.json()
-  const state = await renameTag(id, name ?? '')
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { id, name } = await request.json()
+    const state = await renameTag(user.id, id, name ?? '')
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to rename tag', error)
+    return NextResponse.json({ message: 'Не удалось переименовать тег' }, { status: 400 })
+  }
 }
 
 export async function DELETE(request: Request) {
-  const { id } = await request.json()
-  const state = await deleteTag(id)
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { id } = await request.json()
+    const state = await deleteTag(user.id, id)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to delete tag', error)
+    return NextResponse.json({ message: 'Не удалось удалить тег' }, { status: 400 })
+  }
 }
 
 export async function PUT(request: Request) {
-  const { tagIds } = await request.json()
-  const state = await reorderTags(tagIds)
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { tagIds } = await request.json()
+    const state = await reorderTags(user.id, tagIds)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to reorder tags', error)
+    return NextResponse.json({ message: 'Не удалось упорядочить теги' }, { status: 400 })
+  }
 }

--- a/src/app/api/todos/[id]/route.ts
+++ b/src/app/api/todos/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   toggleTodoCompleted,
   updateTodoTitle,
 } from '@/lib/todoService'
+import { requireUser, UnauthorizedError } from '@/lib/auth/session'
 
 interface PatchBody {
   action: 'rename' | 'toggleCompleted' | 'move' | 'togglePinned'
@@ -15,32 +16,50 @@ interface PatchBody {
 }
 
 export async function PATCH(request: Request, { params }: { params: { id: string } }) {
-  const body = (await request.json()) as PatchBody
-  const { id } = params
+  try {
+    const user = await requireUser()
+    const body = (await request.json()) as PatchBody
+    const { id } = params
 
-  switch (body.action) {
-    case 'rename': {
-      const state = await updateTodoTitle(id, body.title ?? '')
-      return NextResponse.json(state)
+    switch (body.action) {
+      case 'rename': {
+        const state = await updateTodoTitle(user.id, id, body.title ?? '')
+        return NextResponse.json(state)
+      }
+      case 'toggleCompleted': {
+        const state = await toggleTodoCompleted(user.id, id)
+        return NextResponse.json(state)
+      }
+      case 'move': {
+        const state = await moveTodo(user.id, id, body.targetParentId ?? null, body.targetIndex ?? 0)
+        return NextResponse.json(state)
+      }
+      case 'togglePinned': {
+        const state = await togglePinned(user.id, id)
+        return NextResponse.json(state)
+      }
+      default:
+        return NextResponse.json({ error: 'Unsupported action' }, { status: 400 })
     }
-    case 'toggleCompleted': {
-      const state = await toggleTodoCompleted(id)
-      return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
     }
-    case 'move': {
-      const state = await moveTodo(id, body.targetParentId ?? null, body.targetIndex ?? 0)
-      return NextResponse.json(state)
-    }
-    case 'togglePinned': {
-      const state = await togglePinned(id)
-      return NextResponse.json(state)
-    }
-    default:
-      return NextResponse.json({ error: 'Unsupported action' }, { status: 400 })
+    console.error('Failed to update todo', error)
+    return NextResponse.json({ message: 'Не удалось обновить задачу' }, { status: 400 })
   }
 }
 
 export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
-  const state = await deleteTodo(params.id)
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const state = await deleteTodo(user.id, params.id)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to delete todo', error)
+    return NextResponse.json({ message: 'Не удалось удалить задачу' }, { status: 400 })
+  }
 }

--- a/src/app/api/todos/[id]/tags/route.ts
+++ b/src/app/api/todos/[id]/tags/route.ts
@@ -1,14 +1,33 @@
 import { NextResponse } from 'next/server'
 import { attachTagToTodo, detachTagFromTodo } from '@/lib/todoService'
+import { requireUser, UnauthorizedError } from '@/lib/auth/session'
 
 export async function POST(request: Request, { params }: { params: { id: string } }) {
-  const { tagId } = await request.json()
-  const state = await attachTagToTodo(params.id, tagId)
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { tagId } = await request.json()
+    const state = await attachTagToTodo(user.id, params.id, tagId)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to attach tag', error)
+    return NextResponse.json({ message: 'Не удалось добавить тег' }, { status: 400 })
+  }
 }
 
 export async function DELETE(request: Request, { params }: { params: { id: string } }) {
-  const { tagId } = await request.json()
-  const state = await detachTagFromTodo(params.id, tagId)
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { tagId } = await request.json()
+    const state = await detachTagFromTodo(user.id, params.id, tagId)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to remove tag', error)
+    return NextResponse.json({ message: 'Не удалось удалить тег' }, { status: 400 })
+  }
 }

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -1,13 +1,31 @@
 import { NextResponse } from 'next/server'
-import { addTodo, getTodoState } from '@/lib/todoService'
+import { addTodo, getTodoStateForUser } from '@/lib/todoService'
+import { requireUser, UnauthorizedError } from '@/lib/auth/session'
 
 export async function GET() {
-  const state = await getTodoState()
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const state = await getTodoStateForUser(user.id)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    throw error
+  }
 }
 
 export async function POST(request: Request) {
-  const { parentId = null, title, tagIds } = await request.json()
-  const state = await addTodo(parentId, title ?? '', Array.isArray(tagIds) ? tagIds : undefined)
-  return NextResponse.json(state)
+  try {
+    const user = await requireUser()
+    const { parentId = null, title, tagIds } = await request.json()
+    const state = await addTodo(user.id, parentId, title ?? '', Array.isArray(tagIds) ? tagIds : undefined)
+    return NextResponse.json(state)
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ message: 'Unauthorized' }, { status: 401 })
+    }
+    console.error('Failed to add todo', error)
+    return NextResponse.json({ message: 'Не удалось добавить задачу' }, { status: 400 })
+  }
 }

--- a/src/components/TelegramLoginButton.tsx
+++ b/src/components/TelegramLoginButton.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { TelegramAuthPayload } from '@/lib/auth/telegram'
+
+interface TelegramLoginButtonProps {
+  botUsername?: string
+  onAuth: (payload: TelegramAuthPayload) => void
+  disabled?: boolean
+}
+
+export function TelegramLoginButton({ botUsername, onAuth, disabled }: TelegramLoginButtonProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!botUsername) return
+    const container = containerRef.current
+    if (!container) return
+
+    const handleAuth = (payload: TelegramAuthPayload) => {
+      if (disabled) return
+      onAuth(payload)
+    }
+
+    ;(window as any).telegramAuthCallback = handleAuth
+
+    const script = document.createElement('script')
+    script.src = 'https://telegram.org/js/telegram-widget.js?22'
+    script.async = true
+    script.setAttribute('data-telegram-login', botUsername)
+    script.setAttribute('data-size', 'large')
+    script.setAttribute('data-userpic', 'false')
+    script.setAttribute('data-request-access', 'write')
+    script.setAttribute('data-onauth', 'telegramAuthCallback')
+
+    container.innerHTML = ''
+    container.appendChild(script)
+
+    return () => {
+      container.innerHTML = ''
+      if ((window as any).telegramAuthCallback === handleAuth) {
+        delete (window as any).telegramAuthCallback
+      }
+    }
+  }, [botUsername, disabled, onAuth])
+
+  if (!botUsername) {
+    return (
+      <div className="rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+        Укажите NEXT_PUBLIC_TELEGRAM_BOT_USERNAME в настройках окружения.
+      </div>
+    )
+  }
+
+  return <div ref={containerRef} />
+}

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -1,25 +1,28 @@
 'use client'
 
 import type { ChangeEventHandler, FormEventHandler } from 'react'
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { observer } from 'mobx-react-lite'
-import { FiPlus } from 'react-icons/fi'
+import { FiLogOut, FiPlus } from 'react-icons/fi'
 import type { TodoState } from '@/lib/types'
 import { TodoStore } from '@/stores/TodoStore'
 import type { VisibilityMode } from '@/stores/TodoStore'
 import { TodoStoreProvider, useTodoStore } from '@/stores/TodoStoreContext'
+import type { TelegramAuthPayload } from '@/lib/auth/telegram'
 // мини-плейсхолдеры для сортировки больше не используются
 import { PinnedList } from './PinnedList'
 import { PinnedTextView } from './PinnedTextView'
 import { TodoItem } from './TodoItem'
 import { TodoSearchBar } from './TodoSearchBar'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { TelegramLoginButton } from './TelegramLoginButton'
+import Image from 'next/image'
 
 interface TodoAppProps {
   initialState: TodoState
 }
 
-const TodoAppContent = () => {
+const AuthenticatedTodoContent = observer(() => {
   const store = useTodoStore()
   const [newTitle, setNewTitle] = useState('')
   const [isAddModalOpen, setIsAddModalOpen] = useState(false)
@@ -40,14 +43,25 @@ const TodoAppContent = () => {
   const [newPinnedListTitle, setNewPinnedListTitle] = useState('')
   const pinnedListInputRef = useRef<HTMLInputElement>(null)
 
-  const handleAdd = async () => {
+  const closeAddModal = useCallback(() => {
+    setIsAddModalOpen(false)
+    setTimeout(() => setIsAddModalMounted(false), 200)
+  }, [])
+
+  const openAddModal = useCallback(() => {
+    setIsAddModalMounted(true)
+    setSelectedTagIds([])
+    requestAnimationFrame(() => setIsAddModalOpen(true))
+  }, [])
+
+  const handleAdd = useCallback(async () => {
     const trimmed = newTitle.trim()
     if (!trimmed) return
     await store.addTodo(null, trimmed, selectedTagIds)
     setNewTitle('')
     setSelectedTagIds([])
     closeAddModal()
-  }
+  }, [closeAddModal, newTitle, selectedTagIds, store])
 
   const handlePinnedListSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
@@ -86,19 +100,7 @@ const TodoAppContent = () => {
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [isAddModalOpen, newTitle])
-
-  const openAddModal = () => {
-    setIsAddModalMounted(true)
-    setSelectedTagIds([])
-    // next tick to trigger transition
-    requestAnimationFrame(() => setIsAddModalOpen(true))
-  }
-
-  const closeAddModal = () => {
-    setIsAddModalOpen(false)
-    setTimeout(() => setIsAddModalMounted(false), 200)
-  }
+  }, [closeAddModal, handleAdd, isAddModalOpen])
 
   const tabs: { key: 'pinned' | 'all' | 'settings'; label: string }[] = useMemo(
     () => [
@@ -145,35 +147,40 @@ const TodoAppContent = () => {
     <div className="min-h-screen bg-canvas-light text-slate-900">
       <div className="mx-auto flex min-h-screen max-w-4xl flex-col px-4 py-10 sm:px-6 lg:px-8">
         <section className="flex-1 rounded-3xl bg-white/60 p-5 shadow-inner ring-1 ring-white/40">
-          <div className="mb-6 flex items-center justify-between gap-3">
-            <div className="flex rounded-2xl bg-white/70 p-1 text-sm font-medium text-slate-500 shadow-sm ring-1 ring-slate-200/70">
-              {tabs.map((tab) => (
-                <button
-                  key={tab.key}
-                  type="button"
-                  onClick={() => handleSwitchTab(tab.key)}
-                  className={[
-                    'rounded-xl px-4 py-2 transition focus-visible:outline-none',
-                    activeTab === tab.key
-                      ? 'bg-slate-900 text-white shadow-sm'
-                      : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700',
-                  ].join(' ')}
-                >
-                  {tab.label}
-                </button>
-              ))}
+          <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-3">
+              <div className="flex rounded-2xl bg-white/70 p-1 text-sm font-medium text-slate-500 shadow-sm ring-1 ring-slate-200/70">
+                {tabs.map((tab) => (
+                  <button
+                    key={tab.key}
+                    type="button"
+                    onClick={() => handleSwitchTab(tab.key)}
+                    className={[
+                      'rounded-xl px-4 py-2 transition focus-visible:outline-none',
+                      activeTab === tab.key
+                        ? 'bg-slate-900 text-white shadow-sm'
+                        : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700',
+                    ].join(' ')}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
             </div>
-            {activeTab === 'all' && (
-              <button
-                type="button"
-                onClick={openAddModal}
-                className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
-                aria-label="Добавить задачу"
-              >
-                <FiPlus />
-                Добавить
-              </button>
-            )}
+            <div className="flex flex-wrap items-center justify-end gap-3">
+              {activeTab === 'all' && (
+                <button
+                  type="button"
+                  onClick={openAddModal}
+                  className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+                  aria-label="Добавить задачу"
+                >
+                  <FiPlus />
+                  Добавить
+                </button>
+              )}
+              <AuthControls />
+            </div>
           </div>
 
           {activeTab === 'pinned' ? (
@@ -368,19 +375,143 @@ const TodoAppContent = () => {
       </div>
     </div>
   )
-}
+})
 
-const ObservedContent = observer(TodoAppContent)
+const TodoAppContent = observer(() => {
+  const store = useTodoStore()
+
+  if (!store.user) {
+    return <LoginPanel />
+  }
+
+  return <AuthenticatedTodoContent />
+})
 
 export const TodoApp = ({ initialState }: TodoAppProps) => {
   const [store] = useState(() => new TodoStore(initialState))
 
   return (
     <TodoStoreProvider store={store}>
-      <ObservedContent />
+      <TodoAppContent />
     </TodoStoreProvider>
   )
 }
+
+const LoginPanel = () => {
+  const store = useTodoStore()
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const botUsername = process.env.NEXT_PUBLIC_TELEGRAM_BOT_USERNAME
+
+  const handleAuth = useCallback(
+    async (payload: TelegramAuthPayload) => {
+      if (isLoading) return
+      setIsLoading(true)
+      setError(null)
+      try {
+        const response = await fetch('/api/auth/telegram', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        })
+        if (!response.ok) {
+          const data = await response.json().catch(() => null)
+          throw new Error((data as { message?: string } | null)?.message ?? 'Не удалось авторизоваться')
+        }
+        const state = (await response.json()) as TodoState
+        store.setState(state)
+      } catch (authError) {
+        console.error('Failed to authorize via Telegram', authError)
+        setError(authError instanceof Error ? authError.message : 'Не удалось авторизоваться')
+        setIsLoading(false)
+      }
+    },
+    [isLoading, store],
+  )
+
+  return (
+    <div className="min-h-screen bg-canvas-light text-slate-900">
+      <div className="mx-auto flex min-h-screen max-w-lg flex-col justify-center px-4 py-10 sm:px-6 lg:px-8">
+        <div className="rounded-3xl bg-white/70 p-8 shadow-inner ring-1 ring-white/60">
+          <h1 className="text-2xl font-semibold text-slate-800">Вход в приложение</h1>
+          <p className="mt-2 text-sm text-slate-500">
+            Войдите через Telegram, чтобы сохранять свои задачи и закреплённые списки в личном пространстве.
+          </p>
+          <div className="mt-6 flex flex-col items-center gap-4">
+            <TelegramLoginButton botUsername={botUsername} onAuth={handleAuth} disabled={isLoading} />
+            {isLoading && <p className="text-xs text-slate-500">Проверяем данные…</p>}
+            {error && <p className="text-sm text-rose-600">{error}</p>}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const AuthControls = observer(() => {
+  const store = useTodoStore()
+  const user = store.user
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleLogout = useCallback(async () => {
+    if (isLoading) return
+    setIsLoading(true)
+    try {
+      const response = await fetch('/api/auth/logout', { method: 'POST' })
+      if (!response.ok) {
+        const data = await response.json().catch(() => null)
+        throw new Error((data as { message?: string } | null)?.message ?? 'Не удалось выйти из аккаунта')
+      }
+      const state = (await response.json()) as TodoState
+      store.setState(state)
+    } catch (logoutError) {
+      console.error('Failed to logout', logoutError)
+      setIsLoading(false)
+    }
+  }, [isLoading, store])
+
+  if (!user) return null
+
+  const displayName = [user.firstName, user.lastName].filter(Boolean).join(' ') || user.username || 'Пользователь'
+  const initials = [user.firstName, user.lastName]
+    .filter((value): value is string => Boolean(value && value.trim()))
+    .map((value) => value.trim()[0]?.toUpperCase())
+    .join('') || user.username?.[0]?.toUpperCase() || 'T'
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2 rounded-2xl bg-white/80 px-3 py-1.5 text-xs font-medium text-slate-600 shadow-inner ring-1 ring-slate-200/70">
+        {user.photoUrl ? (
+          <Image
+            src={user.photoUrl}
+            alt={displayName}
+            width={32}
+            height={32}
+            className="h-8 w-8 rounded-full object-cover shadow"
+            unoptimized
+          />
+        ) : (
+          <span className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-200 text-sm font-semibold text-slate-600">
+            {initials}
+          </span>
+        )}
+        <div className="flex flex-col leading-tight">
+          <span className="text-sm font-semibold text-slate-700">{displayName}</span>
+          {user.username && <span className="text-xs text-slate-500">@{user.username}</span>}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={handleLogout}
+        disabled={isLoading}
+        className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        <FiLogOut />
+        {isLoading ? 'Выходим…' : 'Выйти'}
+      </button>
+    </div>
+  )
+})
 
 const filterOptions: { value: VisibilityMode; label: string }[] = [
   { value: 'activeOnly', label: 'Только активные' },

--- a/src/lib/auth/session.ts
+++ b/src/lib/auth/session.ts
@@ -1,0 +1,86 @@
+import { cookies } from 'next/headers'
+import { randomBytes } from 'node:crypto'
+import type { Session, User } from '@prisma/client'
+import { prisma } from '../prisma'
+
+export const SESSION_COOKIE_NAME = 'todo_session'
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30 // 30 days
+
+export class UnauthorizedError extends Error {
+  constructor(message = 'Unauthorized') {
+    super(message)
+    this.name = 'UnauthorizedError'
+  }
+}
+
+export interface SessionWithUser extends Session {
+  user: User
+}
+
+export function buildSessionCookie(token: string, expiresAt: Date) {
+  return {
+    name: SESSION_COOKIE_NAME,
+    value: token,
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    path: '/',
+    secure: process.env.NODE_ENV === 'production',
+    expires: expiresAt,
+  }
+}
+
+export function buildClearedSessionCookie() {
+  return {
+    name: SESSION_COOKIE_NAME,
+    value: '',
+    httpOnly: true,
+    sameSite: 'lax' as const,
+    path: '/',
+    secure: process.env.NODE_ENV === 'production',
+    expires: new Date(0),
+  }
+}
+
+export async function createSession(userId: string) {
+  const token = randomBytes(32).toString('hex')
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS)
+  await prisma.session.create({ data: { token, userId, expiresAt } })
+  return { token, expiresAt }
+}
+
+export async function invalidateSession(token: string) {
+  if (!token) return
+  await prisma.session.deleteMany({ where: { token } })
+}
+
+export async function getSessionFromCookies(): Promise<SessionWithUser | null> {
+  const token = cookies().get(SESSION_COOKIE_NAME)?.value
+  if (!token) return null
+
+  const session = await prisma.session.findUnique({ where: { token }, include: { user: true } })
+  if (!session) {
+    cookies().delete(SESSION_COOKIE_NAME)
+    return null
+  }
+
+  if (session.expiresAt.getTime() <= Date.now()) {
+    await prisma.session.delete({ where: { id: session.id } }).catch(() => undefined)
+    cookies().delete(SESSION_COOKIE_NAME)
+    return null
+  }
+
+  return session
+}
+
+export async function getCurrentUser(): Promise<User | null> {
+  const session = await getSessionFromCookies()
+  return session?.user ?? null
+}
+
+export async function requireUser(): Promise<User> {
+  const user = await getCurrentUser()
+  if (!user) {
+    throw new UnauthorizedError()
+  }
+  return user
+}

--- a/src/lib/auth/telegram.ts
+++ b/src/lib/auth/telegram.ts
@@ -1,0 +1,85 @@
+import { createHash, createHmac } from 'node:crypto'
+
+export interface TelegramAuthPayload {
+  id: number | string
+  first_name?: string
+  last_name?: string
+  username?: string
+  photo_url?: string
+  auth_date?: number | string
+  hash?: string
+  [key: string]: unknown
+}
+
+export interface TelegramUserData {
+  telegramId: string
+  firstName: string
+  lastName?: string | null
+  username?: string | null
+  photoUrl?: string | null
+}
+
+const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24
+
+export function verifyTelegramAuth(payload: TelegramAuthPayload): TelegramUserData {
+  const botToken = process.env.TELEGRAM_BOT_TOKEN
+  if (!botToken) {
+    throw new Error('TELEGRAM_BOT_TOKEN is not configured')
+  }
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid Telegram payload')
+  }
+
+  const hash = typeof payload.hash === 'string' ? payload.hash : ''
+  if (!hash) {
+    throw new Error('Missing payload hash')
+  }
+
+  const authDateNumber = Number(payload.auth_date)
+  if (!Number.isFinite(authDateNumber)) {
+    throw new Error('Invalid auth_date')
+  }
+
+  const maxAge = Number(process.env.TELEGRAM_AUTH_MAX_AGE ?? DEFAULT_MAX_AGE_SECONDS)
+  if (Number.isFinite(maxAge) && maxAge > 0) {
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    if (nowSeconds - authDateNumber > maxAge) {
+      throw new Error('Telegram auth data has expired')
+    }
+  }
+
+  const dataCheck = Object.keys(payload)
+    .filter((key) => key !== 'hash' && payload[key] !== undefined && payload[key] !== null)
+    .sort()
+    .map((key) => `${key}=${String(payload[key])}`)
+    .join('\n')
+
+  const secret = createHash('sha256').update(botToken).digest()
+  const expectedHash = createHmac('sha256', secret).update(dataCheck).digest('hex')
+
+  if (expectedHash !== hash) {
+    throw new Error('Failed to verify Telegram signature')
+  }
+
+  const telegramId = String(payload.id ?? '')
+  if (!telegramId) {
+    throw new Error('Missing Telegram user id')
+  }
+
+  const firstName = typeof payload.first_name === 'string' && payload.first_name.trim()
+    ? payload.first_name.trim()
+    : ''
+
+  if (!firstName) {
+    throw new Error('Missing Telegram first name')
+  }
+
+  return {
+    telegramId,
+    firstName,
+    lastName: typeof payload.last_name === 'string' ? payload.last_name : null,
+    username: typeof payload.username === 'string' ? payload.username : null,
+    photoUrl: typeof payload.photo_url === 'string' ? payload.photo_url : null,
+  }
+}

--- a/src/lib/todoService.ts
+++ b/src/lib/todoService.ts
@@ -1,12 +1,10 @@
 import { randomUUID } from 'node:crypto'
-import type { Todo, Tag } from '@prisma/client'
+import type { Todo as PrismaTodo, Tag as PrismaTag, User } from '@prisma/client'
 import { Prisma } from '@prisma/client'
 import { MAX_DEPTH } from './constants'
 import { prisma } from './prisma'
 import type { PinnedListState, TodoNode, TodoState } from './types'
-
-let schemaInitialized = false
-let seedInitialized = false
+import { getCurrentUser } from './auth/session'
 
 interface NormalizedTodoRecord {
   id: string
@@ -26,39 +24,50 @@ interface NormalizedPinnedList {
   order: string[]
 }
 
-async function ensureDatabase() {
-  // No-op: schema is managed by Prisma migrations for Postgres
-  if (schemaInitialized) return
-  schemaInitialized = true
+type SerializableUser = Pick<User, 'id' | 'firstName' | 'lastName' | 'username' | 'photoUrl'>
+
+function createEmptyState(): TodoState {
+  return { todos: [], pinnedLists: [], tags: [], user: null }
 }
 
-async function ensureSeedData() {
-  await ensureDatabase()
-  if (seedInitialized) return
+function serializeUser(user: SerializableUser): NonNullable<TodoState['user']> {
+  return {
+    id: user.id,
+    firstName: user.firstName,
+    lastName: user.lastName ?? null,
+    username: user.username ?? null,
+    photoUrl: user.photoUrl ?? null,
+  }
+}
 
-  // Ensure primary pinned list exists once
-  let primary = await prisma.pinnedList.findFirst({ orderBy: { position: 'asc' } })
+async function ensureUserData(userId: string) {
+  let primary = await prisma.pinnedList.findFirst({ where: { userId }, orderBy: { position: 'asc' } })
   if (!primary) {
     primary = await prisma.pinnedList.create({
-      data: { title: 'Главное', isPrimary: true, isActive: true, position: 0 },
+      data: {
+        userId,
+        title: 'Главное',
+        isPrimary: true,
+        isActive: true,
+        position: 0,
+      },
     })
   } else {
     if (!primary.isPrimary) {
       await prisma.pinnedList.update({ where: { id: primary.id }, data: { isPrimary: true } })
     }
-    // Ensure there is exactly one active list; default to primary if none
-    const active = await prisma.pinnedList.findFirst({ where: { isActive: true } })
+    const active = await prisma.pinnedList.findFirst({ where: { userId, isActive: true } })
     if (!active) {
       await prisma.pinnedList.update({ where: { id: primary.id }, data: { isActive: true } })
     }
   }
 
-  // Seed demo todos only if DB is empty
-  const count = await prisma.todo.count()
-  if (count === 0) {
+  const todoCount = await prisma.todo.count({ where: { userId } })
+  if (todoCount === 0) {
     await prisma.$transaction(async (tx) => {
       const qaChecklist = await tx.todo.create({
         data: {
+          userId,
           title: 'Проверка перед релизом',
           completed: false,
           pinned: false,
@@ -69,6 +78,7 @@ async function ensureSeedData() {
       await tx.todo.createMany({
         data: [
           {
+            userId,
             title: 'Прогнать авто-тесты',
             completed: true,
             completedAt: new Date(),
@@ -77,6 +87,7 @@ async function ensureSeedData() {
             position: 0,
           },
           {
+            userId,
             title: 'Проверить ручные сценарии',
             completed: false,
             pinned: false,
@@ -84,6 +95,7 @@ async function ensureSeedData() {
             position: 1,
           },
           {
+            userId,
             title: 'Согласовать список изменений',
             completed: false,
             pinned: false,
@@ -95,6 +107,7 @@ async function ensureSeedData() {
 
       const designIteration = await tx.todo.create({
         data: {
+          userId,
           title: 'Прототип интерфейса',
           completed: false,
           pinned: false,
@@ -104,6 +117,7 @@ async function ensureSeedData() {
 
       const feedback = await tx.todo.create({
         data: {
+          userId,
           title: 'Собрать обратную связь',
           completed: false,
           pinned: false,
@@ -115,6 +129,7 @@ async function ensureSeedData() {
       await tx.todo.createMany({
         data: [
           {
+            userId,
             title: 'Скетч основных экранов',
             completed: false,
             pinned: false,
@@ -122,6 +137,7 @@ async function ensureSeedData() {
             position: 0,
           },
           {
+            userId,
             title: 'Созвон с командой продукта',
             completed: false,
             pinned: false,
@@ -132,15 +148,11 @@ async function ensureSeedData() {
       })
     })
   }
-
-  seedInitialized = true
 }
 
-async function getPrimaryList() {
-  await ensureSeedData()
-  const primary = await prisma.pinnedList.findFirst({
-    orderBy: { position: 'asc' },
-  })
+async function getPrimaryList(userId: string) {
+  await ensureUserData(userId)
+  const primary = await prisma.pinnedList.findFirst({ where: { userId }, orderBy: { position: 'asc' } })
   if (!primary) {
     throw new Error('Primary pinned list is missing')
   }
@@ -153,43 +165,69 @@ async function getPrimaryList() {
   return primary
 }
 
-async function getActiveList() {
-  await ensureSeedData()
-  let active = await prisma.pinnedList.findFirst({ where: { isActive: true }, orderBy: { position: 'asc' } })
+async function getActiveList(userId: string) {
+  await ensureUserData(userId)
+  let active = await prisma.pinnedList.findFirst({ where: { userId, isActive: true }, orderBy: { position: 'asc' } })
   if (!active) {
-    const primary = await getPrimaryList()
+    const primary = await getPrimaryList(userId)
     active = await prisma.pinnedList.update({ where: { id: primary.id }, data: { isActive: true } })
   }
   return active
 }
 
-async function getNextTodoPosition(parentId: string | null) {
-  await ensureSeedData()
+
+async function getNextTodoPosition(userId: string, parentId: string | null) {
+  await ensureUserData(userId)
   const lastTodo = await prisma.todo.findFirst({
-    where: { parentId },
+    where: { userId, parentId },
     orderBy: { position: 'desc' },
   })
   return (lastTodo?.position ?? -1) + 1
 }
 
-async function getNextPinnedListPosition() {
-  await ensureSeedData()
+async function getNextPinnedListPosition(userId: string) {
+  await ensureUserData(userId)
   const lastList = await prisma.pinnedList.findFirst({
+    where: { userId },
     orderBy: { position: 'desc' },
   })
   return (lastList?.position ?? -1) + 1
 }
 
-async function getNextPinnedTodoPosition(listId: string) {
-  await ensureSeedData()
+async function getNextPinnedTodoPosition(userId: string, listId: string) {
+  await ensureUserData(userId)
   const lastEntry = await prisma.pinnedTodo.findFirst({
-    where: { pinnedListId: listId },
+    where: { pinnedList: { userId }, pinnedListId: listId },
     orderBy: { position: 'desc' },
   })
   return (lastEntry?.position ?? -1) + 1
 }
 
-function buildTree(todos: (Todo & { tags: Tag[] })[]): TodoNode[] {
+async function findTodoForUser(userId: string, id: string) {
+  const todo = await prisma.todo.findUnique({ where: { id } })
+  if (!todo || todo.userId !== userId) {
+    return null
+  }
+  return todo
+}
+
+async function findPinnedListForUser(userId: string, id: string) {
+  const list = await prisma.pinnedList.findUnique({ where: { id } })
+  if (!list || list.userId !== userId) {
+    return null
+  }
+  return list
+}
+
+async function filterUserTagIds(userId: string, tagIds: string[]): Promise<string[]> {
+  if (!Array.isArray(tagIds) || tagIds.length === 0) return []
+  const unique = Array.from(new Set(tagIds.filter((id) => typeof id === 'string' && id.trim().length > 0)))
+  if (unique.length === 0) return []
+  const rows = await prisma.tag.findMany({ where: { userId, id: { in: unique } }, select: { id: true } })
+  return rows.map((row) => row.id)
+}
+
+function buildTree(todos: (PrismaTodo & { tags: PrismaTag[] })[]): TodoNode[] {
   const nodes = new Map<string, TodoNode>()
   const roots: TodoNode[] = []
 
@@ -221,10 +259,13 @@ function buildTree(todos: (Todo & { tags: Tag[] })[]): TodoNode[] {
   return roots
 }
 
-async function composePinnedLists(): Promise<PinnedListState[]> {
+async function composePinnedLists(userId: string): Promise<PinnedListState[]> {
   const [lists, entries] = await Promise.all([
-    prisma.pinnedList.findMany({ orderBy: { position: 'asc' } }),
-    prisma.pinnedTodo.findMany({ orderBy: [{ pinnedListId: 'asc' }, { position: 'asc' }] }),
+    prisma.pinnedList.findMany({ where: { userId }, orderBy: { position: 'asc' } }),
+    prisma.pinnedTodo.findMany({
+      where: { pinnedList: { userId } },
+      orderBy: [{ pinnedListId: 'asc' }, { position: 'asc' }],
+    }),
   ])
 
   return lists.map((list) => ({
@@ -233,21 +274,47 @@ async function composePinnedLists(): Promise<PinnedListState[]> {
     order: entries.filter((entry) => entry.pinnedListId === list.id).map((entry) => entry.todoId),
     isPrimary: list.isPrimary,
     position: list.position,
-    isActive: (list as any).isActive ?? false,
+    isActive: list.isActive,
   }))
 }
 
-export async function getTodoState(): Promise<TodoState> {
-  await ensureSeedData()
+async function buildTodoStateForUser(user: SerializableUser): Promise<TodoState> {
+  await ensureUserData(user.id)
 
   const [todos, tags] = await Promise.all([
-    prisma.todo.findMany({ include: { tags: true } }),
-    prisma.tag.findMany({ orderBy: { position: 'asc' } }),
+    prisma.todo.findMany({ where: { userId: user.id }, include: { tags: true } }),
+    prisma.tag.findMany({ where: { userId: user.id }, orderBy: { position: 'asc' } }),
   ])
-  const tree = buildTree(todos)
-  const pinnedLists = await composePinnedLists()
 
-  return { todos: tree, pinnedLists, tags }
+  const tree = buildTree(todos)
+  const pinnedLists = await composePinnedLists(user.id)
+
+  return {
+    todos: tree,
+    pinnedLists,
+    tags,
+    user: serializeUser(user),
+  }
+}
+
+async function getTodoStateForUserId(userId: string): Promise<TodoState> {
+  const user = await prisma.user.findUnique({ where: { id: userId } })
+  if (!user) {
+    return createEmptyState()
+  }
+  return buildTodoStateForUser(user)
+}
+
+export async function getTodoState(): Promise<TodoState> {
+  const user = await getCurrentUser()
+  if (!user) {
+    return createEmptyState()
+  }
+  return buildTodoStateForUser(user)
+}
+
+export async function getTodoStateForUser(userId: string): Promise<TodoState> {
+  return getTodoStateForUserId(userId)
 }
 
 function normalizeTodos(
@@ -361,7 +428,7 @@ function normalizePinnedLists(
   return normalized
 }
 
-export async function replaceTodoState(state: unknown): Promise<TodoState> {
+export async function replaceTodoState(userId: string, state: unknown): Promise<TodoState> {
   const todos: NormalizedTodoRecord[] = []
   const idSet = new Set<string>()
   const parsed = (state as Partial<TodoState>) ?? {}
@@ -425,18 +492,19 @@ export async function replaceTodoState(state: unknown): Promise<TodoState> {
   })
 
   await prisma.$transaction(async (tx) => {
-    await tx.pinnedTodo.deleteMany()
-    await tx.pinnedList.deleteMany()
-    await tx.tag.deleteMany()
-    await tx.todo.deleteMany()
+    await tx.pinnedTodo.deleteMany({ where: { pinnedList: { userId } } })
+    await tx.pinnedList.deleteMany({ where: { userId } })
+    await tx.tag.deleteMany({ where: { userId } })
+    await tx.todo.deleteMany({ where: { userId } })
 
     if (tagRecords.length > 0) {
-      await tx.tag.createMany({ data: tagRecords })
+      await tx.tag.createMany({ data: tagRecords.map((record) => ({ ...record, userId })) })
     }
 
     for (const todo of todos) {
       await tx.todo.create({
         data: {
+          userId,
           id: todo.id,
           title: todo.title,
           completed: todo.completed,
@@ -460,10 +528,12 @@ export async function replaceTodoState(state: unknown): Promise<TodoState> {
     for (const list of pinnedLists) {
       await tx.pinnedList.create({
         data: {
+          userId,
           id: list.id,
           title: list.title,
           position: list.position,
           isPrimary: list.isPrimary,
+          isActive: Boolean(list.isActive),
         },
       })
 
@@ -479,51 +549,57 @@ export async function replaceTodoState(state: unknown): Promise<TodoState> {
     }
   })
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-async function getTodoDepth(id: string): Promise<number> {
-  await ensureSeedData()
+async function getTodoDepth(userId: string, id: string): Promise<number> {
+  await ensureUserData(userId)
   const rows = await prisma.$queryRaw<{ depth: number | null }[]>`
     WITH RECURSIVE ancestors AS (
-      SELECT "parentId", 0::int AS depth FROM "Todo" WHERE "id" = ${id}
+      SELECT "parentId", 0::int AS depth FROM "Todo" WHERE "id" = ${id} AND "userId" = ${userId}
       UNION ALL
       SELECT t."parentId", ancestors.depth + 1
       FROM "Todo" t
       JOIN ancestors ON t."id" = ancestors."parentId"
+      WHERE t."userId" = ${userId}
     )
     SELECT COALESCE(MAX(depth), 0) AS depth FROM ancestors;
   `
   return rows[0]?.depth ?? 0
 }
 
-async function getSubtreeDepth(id: string): Promise<number> {
-  await ensureSeedData()
+async function getSubtreeDepth(userId: string, id: string): Promise<number> {
+  await ensureUserData(userId)
   const rows = await prisma.$queryRaw<{ maxDepth: number | null }[]>`
     WITH RECURSIVE tree AS (
-      SELECT "id", "parentId", 0::int AS depth FROM "Todo" WHERE "id" = ${id}
+      SELECT "id", "parentId", 0::int AS depth FROM "Todo" WHERE "id" = ${id} AND "userId" = ${userId}
       UNION ALL
       SELECT t."id", t."parentId", tree.depth + 1
       FROM "Todo" t
       JOIN tree ON t."parentId" = tree."id"
+      WHERE t."userId" = ${userId}
     )
     SELECT COALESCE(MAX(depth), 0) AS "maxDepth" FROM tree;
   `
   return rows[0]?.maxDepth ?? 0
 }
 
-export async function addTodo(parentId: string | null, title: string, tagIds?: string[]): Promise<TodoState> {
+export async function addTodo(userId: string, parentId: string | null, title: string, tagIds?: string[]): Promise<TodoState> {
   const trimmed = title.trim()
   if (!trimmed) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
-  await ensureSeedData()
+  await ensureUserData(userId)
 
   if (parentId) {
-    const parentDepth = await getTodoDepth(parentId)
+    const parent = await findTodoForUser(userId, parentId)
+    if (!parent) {
+      return getTodoStateForUserId(userId)
+    }
+    const parentDepth = await getTodoDepth(userId, parentId)
     if (parentDepth >= MAX_DEPTH) {
-      return getTodoState()
+      return getTodoStateForUserId(userId)
     }
   }
 
@@ -531,18 +607,21 @@ export async function addTodo(parentId: string | null, title: string, tagIds?: s
   await prisma.$transaction(async (tx) => {
     // Shift positions of existing siblings (including roots when parentId is null)
     await tx.todo.updateMany({
-      where: { parentId },
+      where: { userId, parentId },
       data: { position: { increment: 1 } },
     })
 
+    const connectTagIds = await filterUserTagIds(userId, Array.isArray(tagIds) ? tagIds : [])
+
     // Create the new todo at position 0
-    const created = await tx.todo.create({
+    await tx.todo.create({
       data: {
+        userId,
         title: trimmed,
         parentId,
         position: 0,
-        ...(Array.isArray(tagIds) && tagIds.length > 0
-          ? { tags: { connect: Array.from(new Set(tagIds)).map((id) => ({ id })) } }
+        ...(connectTagIds.length > 0
+          ? { tags: { connect: connectTagIds.map((id) => ({ id })) } }
           : {}),
       },
     })
@@ -550,209 +629,231 @@ export async function addTodo(parentId: string | null, title: string, tagIds?: s
     // If adding as pinned (later via togglePinned), do nothing here.
   })
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function updateTodoTitle(id: string, title: string): Promise<TodoState> {
+export async function updateTodoTitle(userId: string, id: string, title: string): Promise<TodoState> {
   const trimmed = title.trim()
   if (!trimmed) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
-  await ensureSeedData()
+  await ensureUserData(userId)
+  const todo = await findTodoForUser(userId, id)
+  if (!todo) {
+    return getTodoStateForUserId(userId)
+  }
 
   await prisma.todo.update({
     where: { id },
     data: { title: trimmed },
   })
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function toggleTodoCompleted(id: string): Promise<TodoState> {
-  await ensureSeedData()
-  const todo = await prisma.todo.findUnique({ where: { id } })
+export async function toggleTodoCompleted(userId: string, id: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  const todo = await findTodoForUser(userId, id)
   if (!todo) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
   await prisma.todo.update({
     where: { id },
-  data: { completed: !todo.completed, completedAt: todo.completed ? null : new Date() },
+    data: { completed: !todo.completed, completedAt: todo.completed ? null : new Date() },
   })
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function deleteTodo(id: string): Promise<TodoState> {
-  await ensureSeedData()
+export async function deleteTodo(userId: string, id: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  const todo = await findTodoForUser(userId, id)
+  if (!todo) {
+    return getTodoStateForUserId(userId)
+  }
   await prisma.todo.delete({ where: { id } })
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
 // ----- Tags API -----
-export async function listTags(): Promise<TodoState> {
-  await ensureSeedData()
-  return getTodoState()
+export async function listTags(userId: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  return getTodoStateForUserId(userId)
 }
 
-export async function addTag(name: string): Promise<TodoState> {
+export async function addTag(userId: string, name: string): Promise<TodoState> {
   const trimmed = name.trim()
-  if (!trimmed) return getTodoState()
-  await ensureSeedData()
-  const maxPosition = await prisma.tag.findFirst({ orderBy: { position: 'desc' } })
+  if (!trimmed) return getTodoStateForUserId(userId)
+  await ensureUserData(userId)
+  const maxPosition = await prisma.tag.findFirst({ where: { userId }, orderBy: { position: 'desc' } })
   const position = (maxPosition?.position ?? -1) + 1
   const isSystem = trimmed === 'Проект' || trimmed === 'Раздел'
-  await prisma.tag.create({ data: { name: trimmed, position, isSystem } })
-  return getTodoState()
+  await prisma.tag.create({ data: { userId, name: trimmed, position, isSystem } })
+  return getTodoStateForUserId(userId)
 }
 
-export async function renameTag(id: string, name: string): Promise<TodoState> {
+export async function renameTag(userId: string, id: string, name: string): Promise<TodoState> {
   const trimmed = name.trim()
-  if (!trimmed) return getTodoState()
-  await ensureSeedData()
+  if (!trimmed) return getTodoStateForUserId(userId)
+  await ensureUserData(userId)
+  const tag = await prisma.tag.findUnique({ where: { id } })
+  if (!tag || tag.userId !== userId) {
+    return getTodoStateForUserId(userId)
+  }
   const isSystem = trimmed === 'Проект' || trimmed === 'Раздел'
   await prisma.tag.update({ where: { id }, data: { name: trimmed, isSystem } })
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function deleteTag(id: string): Promise<TodoState> {
-  await ensureSeedData()
+export async function deleteTag(userId: string, id: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  const tag = await prisma.tag.findUnique({ where: { id } })
+  if (!tag || tag.userId !== userId) {
+    return getTodoStateForUserId(userId)
+  }
   await prisma.tag.delete({ where: { id } })
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function reorderTags(tagIds: string[]): Promise<TodoState> {
-  await ensureSeedData()
+export async function reorderTags(userId: string, tagIds: string[]): Promise<TodoState> {
+  await ensureUserData(userId)
+  const validIds = await filterUserTagIds(userId, tagIds)
   await prisma.$transaction(
-    tagIds.map((id, index) =>
+    validIds.map((id, index) =>
       prisma.tag.update({
         where: { id },
         data: { position: index },
       }),
     ),
   )
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function attachTagToTodo(todoId: string, tagId: string): Promise<TodoState> {
-  await ensureSeedData()
-  // Ограничения системных тегов: "Проект" и "Раздел"
+export async function attachTagToTodo(userId: string, todoId: string, tagId: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  const todo = await findTodoForUser(userId, todoId)
+  if (!todo) return getTodoStateForUserId(userId)
   const tag = await prisma.tag.findUnique({ where: { id: tagId } })
-  if (!tag) return getTodoState()
+  if (!tag || tag.userId !== userId) return getTodoStateForUserId(userId)
 
   if (tag.name === 'Проект') {
-    // Нельзя если на этом узле или у потомков есть "Раздел"
     const rows = await prisma.$queryRaw<{ exists: boolean }[]>`
       WITH RECURSIVE subtree AS (
-        SELECT "id" FROM "Todo" WHERE "id" = ${todoId}
+        SELECT "id" FROM "Todo" WHERE "id" = ${todoId} AND "userId" = ${userId}
         UNION ALL
         SELECT t."id" FROM "Todo" t
         JOIN subtree ON t."parentId" = subtree."id"
+        WHERE t."userId" = ${userId}
       )
       SELECT EXISTS(
         SELECT 1 FROM "Todo" tt
         JOIN "_TagToTodo" j ON j."B" = tt."id"
         JOIN "Tag" tg ON tg."id" = j."A"
-        WHERE tg."name" = 'Раздел' AND tt."id" IN (SELECT "id" FROM subtree)
+        WHERE tg."name" = 'Раздел' AND tg."userId" = ${userId} AND tt."id" IN (SELECT "id" FROM subtree)
       ) AS exists;
     `
-    if (rows[0]?.exists) return getTodoState()
+    if (rows[0]?.exists) return getTodoStateForUserId(userId)
   }
 
   if (tag.name === 'Раздел') {
-    // Разрешен только если в иерархии вверх есть "Проект"
     const rows = await prisma.$queryRaw<{ hasProject: boolean }[]>`
       WITH RECURSIVE ancestors AS (
-        SELECT "id", "parentId" FROM "Todo" WHERE "id" = ${todoId}
+        SELECT "id", "parentId" FROM "Todo" WHERE "id" = ${todoId} AND "userId" = ${userId}
         UNION ALL
         SELECT t."id", t."parentId" FROM "Todo" t
         JOIN ancestors a ON a."parentId" = t."id"
+        WHERE t."userId" = ${userId}
       )
       SELECT EXISTS(
         SELECT 1 FROM ancestors anc
         JOIN "_TagToTodo" j ON j."B" = anc."id"
         JOIN "Tag" tg ON tg."id" = j."A"
-        WHERE tg."name" = 'Проект'
+        WHERE tg."name" = 'Проект' AND tg."userId" = ${userId}
       ) AS "hasProject";
     `
-    if (!rows[0]?.hasProject) return getTodoState()
+    if (!rows[0]?.hasProject) return getTodoStateForUserId(userId)
   }
 
   await prisma.todo.update({ where: { id: todoId }, data: { tags: { connect: { id: tagId } } } })
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function detachTagFromTodo(todoId: string, tagId: string): Promise<TodoState> {
-  await ensureSeedData()
+export async function detachTagFromTodo(userId: string, todoId: string, tagId: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  const todo = await findTodoForUser(userId, todoId)
+  if (!todo) return getTodoStateForUserId(userId)
+  const tag = await prisma.tag.findUnique({ where: { id: tagId } })
+  if (!tag || tag.userId !== userId) return getTodoStateForUserId(userId)
   await prisma.todo.update({ where: { id: todoId }, data: { tags: { disconnect: { id: tagId } } } })
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
 export async function moveTodo(
+  userId: string,
   id: string,
   targetParentId: string | null,
   targetIndex: number,
 ): Promise<TodoState> {
-  await ensureSeedData()
-  const todo = await prisma.todo.findUnique({ where: { id } })
+  await ensureUserData(userId)
+  const todo = await findTodoForUser(userId, id)
   if (!todo) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
   if (targetParentId) {
-    const parentExists = await prisma.todo.findUnique({ where: { id: targetParentId } })
+    if (targetParentId === id) {
+      return getTodoStateForUserId(userId)
+    }
+    const parentExists = await findTodoForUser(userId, targetParentId)
     if (!parentExists) {
-      return getTodoState()
+      return getTodoStateForUserId(userId)
     }
 
-    if (parentExists.id === id) {
-      return getTodoState()
-    }
-
-    const parentDepth = await getTodoDepth(targetParentId)
-    const subtreeDepth = await getSubtreeDepth(id)
+    const parentDepth = await getTodoDepth(userId, targetParentId)
+    const subtreeDepth = await getSubtreeDepth(userId, id)
     if (parentDepth + 1 + subtreeDepth > MAX_DEPTH) {
-      return getTodoState()
+      return getTodoStateForUserId(userId)
     }
 
-    // ensure not moving into descendant (single query via recursive CTE)
     const descendantRows = await prisma.$queryRaw<{ exists: boolean }[]>`
       WITH RECURSIVE subtree AS (
-        SELECT "id" FROM "Todo" WHERE "id" = ${id}
+        SELECT "id" FROM "Todo" WHERE "id" = ${id} AND "userId" = ${userId}
         UNION ALL
         SELECT t."id" FROM "Todo" t
         JOIN subtree ON t."parentId" = subtree."id"
+        WHERE t."userId" = ${userId}
       )
       SELECT EXISTS(SELECT 1 FROM subtree WHERE "id" = ${targetParentId}) AS exists;
     `
     if (descendantRows[0]?.exists) {
-      return getTodoState()
+      return getTodoStateForUserId(userId)
     }
   } else {
-    const subtreeDepth = await getSubtreeDepth(id)
+    const subtreeDepth = await getSubtreeDepth(userId, id)
     if (subtreeDepth > MAX_DEPTH) {
-      return getTodoState()
+      return getTodoStateForUserId(userId)
     }
   }
 
   const sourceParentId = todo.parentId
 
   const sourceSiblings = await prisma.todo.findMany({
-    where: { parentId: sourceParentId },
+    where: { userId, parentId: sourceParentId },
     orderBy: { position: 'asc' },
   })
 
   const targetSiblings = targetParentId === sourceParentId
     ? sourceSiblings
     : await prisma.todo.findMany({
-      where: { parentId: targetParentId },
+      where: { userId, parentId: targetParentId },
       orderBy: { position: 'asc' },
     })
 
   const currentIndex = sourceSiblings.findIndex((item) => item.id === id)
   if (currentIndex === -1) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
   let nextIndex = targetIndex
@@ -766,7 +867,6 @@ export async function moveTodo(
     const bounded = Math.min(Math.max(nextIndex, 0), order.length)
     order.splice(bounded, 0, id)
 
-    // Single SQL UPDATE for all affected rows (same parent)
     const rows = order.map((todoId, index) =>
       Prisma.sql`(${todoId}, ${sourceParentId}, ${index})`,
     )
@@ -777,7 +877,7 @@ export async function moveTodo(
       FROM (VALUES ${Prisma.join(rows)}) AS v(id, parent_id, position)
       WHERE t."id" = v.id;`
 
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
   const sourceOrder = sourceSiblings.filter((item) => item.id !== id).map((item) => item.id)
@@ -785,7 +885,6 @@ export async function moveTodo(
   const bounded = Math.min(Math.max(nextIndex, 0), targetOrder.length)
   targetOrder.splice(bounded, 0, id)
 
-  // Single SQL UPDATE for both source and target lists (cross-parent move)
   const rows = [
     ...sourceOrder.map((todoId, index) =>
       Prisma.sql`(${todoId}, ${sourceParentId}, ${index})`,
@@ -803,25 +902,24 @@ export async function moveTodo(
       WHERE t."id" = v.id;`
   }
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function togglePinned(id: string): Promise<TodoState> {
-  await ensureSeedData()
-  const todo = await prisma.todo.findUnique({ where: { id } })
+export async function togglePinned(userId: string, id: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  const todo = await findTodoForUser(userId, id)
   if (!todo) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
   if (todo.pinned) {
     await prisma.$transaction([
       prisma.todo.update({ where: { id }, data: { pinned: false } }),
-      prisma.pinnedTodo.deleteMany({ where: { todoId: id } }),
+      prisma.pinnedTodo.deleteMany({ where: { todoId: id, pinnedList: { userId } } }),
     ])
   } else {
-    // Choose active list if set, otherwise primary
-    const active = await getActiveList()
-    const position = await getNextPinnedTodoPosition(active.id)
+    const active = await getActiveList(userId)
+    const position = await getNextPinnedTodoPosition(userId, active.id)
     await prisma.$transaction([
       prisma.todo.update({ where: { id }, data: { pinned: true } }),
       prisma.pinnedTodo.create({
@@ -834,47 +932,47 @@ export async function togglePinned(id: string): Promise<TodoState> {
     ])
   }
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
 export async function movePinnedTodo(
+  userId: string,
   todoId: string,
   targetListId: string,
   targetIndex: number,
 ): Promise<TodoState> {
-  await ensureSeedData()
-  const entry = await prisma.pinnedTodo.findFirst({ where: { todoId } })
+  await ensureUserData(userId)
+  const entry = await prisma.pinnedTodo.findFirst({ where: { todoId, pinnedList: { userId } } })
   if (!entry) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
-  const targetList = await prisma.pinnedList.findUnique({ where: { id: targetListId } })
+  const targetList = await findPinnedListForUser(userId, targetListId)
   if (!targetList) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
   const sourceListId = entry.pinnedListId
   const sameList = sourceListId === targetListId
 
   const sourceEntries = await prisma.pinnedTodo.findMany({
-    where: { pinnedListId: sourceListId },
+    where: { pinnedListId: sourceListId, pinnedList: { userId } },
     orderBy: { position: 'asc' },
   })
 
   const targetEntries = sameList
     ? sourceEntries
     : await prisma.pinnedTodo.findMany({
-      where: { pinnedListId: targetListId },
+      where: { pinnedListId: targetListId, pinnedList: { userId } },
       orderBy: { position: 'asc' },
     })
 
   const boundedIndex = Math.min(Math.max(targetIndex, 0), targetEntries.length)
 
   if (sameList) {
-    const ids = sourceEntries.map((item) => item.id)
     const todoIndex = sourceEntries.findIndex((item) => item.todoId === todoId)
     if (todoIndex === -1) {
-      return getTodoState()
+      return getTodoStateForUserId(userId)
     }
 
     const reordered = [...sourceEntries]
@@ -913,58 +1011,64 @@ export async function movePinnedTodo(
     ])
   }
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function addPinnedList(title: string): Promise<TodoState> {
+export async function addPinnedList(userId: string, title: string): Promise<TodoState> {
   const trimmed = title.trim()
   if (!trimmed) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
-  await ensureSeedData()
+  await ensureUserData(userId)
 
-  const position = await getNextPinnedListPosition()
+  const position = await getNextPinnedListPosition(userId)
+  const hasActive = await prisma.pinnedList.findFirst({ where: { userId, isActive: true } })
   await prisma.pinnedList.create({
     data: {
+      userId,
       title: trimmed,
       position,
       isPrimary: position === 0,
-      isActive: position === 0 && !(await prisma.pinnedList.findFirst({ where: { isActive: true } })),
+      isActive: position === 0 ? true : !hasActive,
     },
   })
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function renamePinnedList(id: string, title: string): Promise<TodoState> {
+export async function renamePinnedList(userId: string, id: string, title: string): Promise<TodoState> {
   const trimmed = title.trim()
   if (!trimmed) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
-  await ensureSeedData()
+  await ensureUserData(userId)
+  const list = await findPinnedListForUser(userId, id)
+  if (!list) {
+    return getTodoStateForUserId(userId)
+  }
 
   await prisma.pinnedList.update({
     where: { id },
     data: { title: trimmed },
   })
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function deletePinnedList(id: string): Promise<TodoState> {
-  await ensureSeedData()
-  const list = await prisma.pinnedList.findUnique({ where: { id } })
+export async function deletePinnedList(userId: string, id: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  const list = await findPinnedListForUser(userId, id)
   if (!list) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
   if (list.isPrimary) {
-    return getTodoState()
+    return getTodoStateForUserId(userId)
   }
 
-  const primary = await getPrimaryList()
+  const primary = await getPrimaryList(userId)
 
   await prisma.$transaction(async (tx) => {
     const entries = await tx.pinnedTodo.findMany({
@@ -995,7 +1099,6 @@ export async function deletePinnedList(id: string): Promise<TodoState> {
     }
 
     await tx.pinnedTodo.deleteMany({ where: { pinnedListId: id } })
-    // If the deleted list was active, switch active to primary
     const wasActive = list.isActive
     await tx.pinnedList.delete({ where: { id } })
     if (wasActive) {
@@ -1003,16 +1106,16 @@ export async function deletePinnedList(id: string): Promise<TodoState> {
     }
   })
 
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }
 
-export async function setActivePinnedList(id: string): Promise<TodoState> {
-  await ensureSeedData()
-  const list = await prisma.pinnedList.findUnique({ where: { id } })
-  if (!list) return getTodoState()
+export async function setActivePinnedList(userId: string, id: string): Promise<TodoState> {
+  await ensureUserData(userId)
+  const list = await findPinnedListForUser(userId, id)
+  if (!list) return getTodoStateForUserId(userId)
   await prisma.$transaction(async (tx) => {
-    await tx.pinnedList.updateMany({ data: { isActive: false } })
+    await tx.pinnedList.updateMany({ where: { userId }, data: { isActive: false } })
     await tx.pinnedList.update({ where: { id }, data: { isActive: true } })
   })
-  return getTodoState()
+  return getTodoStateForUserId(userId)
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -23,8 +23,17 @@ export interface PinnedListState {
   isActive?: boolean
 }
 
+export interface TodoUser {
+  id: string
+  firstName: string
+  lastName?: string | null
+  username?: string | null
+  photoUrl?: string | null
+}
+
 export interface TodoState {
   todos: TodoNode[]
   pinnedLists: PinnedListState[]
   tags?: Tag[]
+  user: TodoUser | null
 }

--- a/src/stores/TodoStore.ts
+++ b/src/stores/TodoStore.ts
@@ -27,6 +27,7 @@ export class TodoStore {
   todos: TodoNode[] = []
   pinnedLists: PinnedListState[] = []
   tags: Tag[] = []
+  user: TodoState['user'] | null = null
   draggedId: string | null = null
   // Set со свернутыми узлами дерева (хранит id задач)
   collapsedIds: Set<string> = new Set()
@@ -51,6 +52,7 @@ export class TodoStore {
     this.todos = initialState.todos
     this.pinnedLists = initialState.pinnedLists
     this.tags = initialState.tags ?? []
+    this.user = initialState.user ?? null
     this.loadCollapsed()
     this.loadPinnedCollapsed()
     this.loadFilters()
@@ -99,6 +101,10 @@ export class TodoStore {
   async refresh() {
     try {
       const response = await fetch('/api/state', { cache: 'no-store' })
+      if (response.status === 401) {
+        this.setState({ todos: [], pinnedLists: [], tags: [], user: null })
+        return
+      }
       if (!response.ok) {
         throw new Error('Failed to load state')
       }
@@ -150,6 +156,7 @@ export class TodoStore {
     this.todos = state.todos
     this.pinnedLists = state.pinnedLists
     this.tags = state.tags ?? []
+    this.user = state.user ?? null
   }
 
   // ---- Filters API ----
@@ -441,6 +448,10 @@ export class TodoStore {
         },
       })
 
+      if (response.status === 401) {
+        this.setState({ todos: [], pinnedLists: [], tags: [], user: null })
+        return
+      }
       if (!response.ok) {
         throw new Error(`Request failed: ${response.status}`)
       }


### PR DESCRIPTION
## Summary
- add Telegram login/logout endpoints, session helpers, and Prisma schema updates for storing Telegram users
- scope todo, tag, and pinned list APIs plus state helpers to the authenticated user
- add a Telegram login button with guarded UI and update the client to satisfy React/Next.js lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ea5bc3570c83248a59d860a300a6f8