### PR TITLE
feat: add mind map FastAPI service and viewer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,8 @@
 # 3. Либо для быстрого прототипирования без миграций: pnpm db:push
 
 DATABASE_URL="file:./dev.db"
+# URL FastAPI сервиса для просмотра майнд-карт
+MINDMAP_API_URL="http://localhost:8000"
 
 ############################################################
 # РЕЖИМ PRODUCTION (PostgreSQL)
@@ -27,6 +29,7 @@ DATABASE_URL="file:./dev.db"
 
 # DATABASE_URL="postgresql://user:password@localhost:5432/todo_app?schema=public"
 # SHADOW_DATABASE_URL="postgresql://user:password@localhost:5432/todo_app_shadow?schema=public"
+# MINDMAP_API_URL="https://your-domain.example/api"
 
 ############################################################
 # ПРИМЕЧАНИЯ

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,2 +1,5 @@
 # Локальная БД разработки (SQLite)
 DATABASE_URL="file:./dev.db"
+
+# URL FastAPI сервиса для майнд-карт
+MINDMAP_API_URL="http://localhost:8000"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@
 - добавление, редактирование, удаление элементов;
 - отметка задач как выполненных и снятие отметки;
 - минималистичный светлый дизайн с иконками вместо текстовых кнопок;
-- закреплённые слоты (например, на дни) с возможностью сворачивания/разворачивания.
+- закреплённые слоты (например, на дни) с возможностью сворачивания/разворачивания;
+- просмотр майнд-карт, хранящихся в PostgreSQL с pgvector, через отдельный FastAPI сервис.
 
 ## Технологии
 - Next.js 14 + TypeScript;
 - Prisma ORM с SQLite;
 - MobX для клиентского состояния;
 - Tailwind CSS для стилизации;
-- HTML5 drag-and-drop.
+- HTML5 drag-and-drop;
+- FastAPI + SQLAlchemy + PostgreSQL (pgvector) для сервиса майнд-карт.
 
 ## Быстрый старт
 
@@ -33,6 +35,33 @@ pnpm dev
 ```
 
 Приложение будет доступно на `http://localhost:3000`.
+
+## Mind map: FastAPI + PostgreSQL (pgvector)
+
+Для визуализации майнд-карт используется отдельный Python-сервис на FastAPI. Данные хранятся в PostgreSQL с расширением `pgvector`.
+
+1. Запустите PostgreSQL и активируйте расширение:
+   ```sql
+   CREATE EXTENSION IF NOT EXISTS vector;
+   ```
+   Пример запуска в Docker:
+   ```bash
+   docker run --name mindmap-pg -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d pgvector/pgvector:pg16
+   ```
+2. Скопируйте переменные окружения и укажите строку подключения:
+   ```bash
+   cp mindmap_api/.env.example mindmap_api/.env  # при необходимости создайте файл
+   export MINDMAP_DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5432/mindmap"
+   ```
+3. Установите зависимости и запустите сервер:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r mindmap_api/requirements.txt
+   uvicorn mindmap_api.main:app --reload  # либо pnpm mindmap:api при активированном окружении
+   ```
+4. По умолчанию сервис создаёт демонстрационную майнд-карту. Swagger доступен по адресу `http://localhost:8000/docs`.
+5. Включите URL сервиса для фронтенда (`MINDMAP_API_URL`), чтобы страница `/mind-map` использовала актуальные данные из БД.
 
 ## Полезные скрипты
 

--- a/mindmap_api/.env.example
+++ b/mindmap_api/.env.example
@@ -1,0 +1,2 @@
+# URL подключения к PostgreSQL с включённым расширением pgvector
+MINDMAP_DATABASE_URL="postgresql+psycopg://postgres:postgres@localhost:5432/mindmap"

--- a/mindmap_api/database.py
+++ b/mindmap_api/database.py
@@ -1,0 +1,58 @@
+"""Database utilities for the mind map FastAPI service."""
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+
+load_dotenv()
+
+
+Base = declarative_base()
+
+
+def _build_engine() -> Engine:
+    database_url = os.getenv(
+        "MINDMAP_DATABASE_URL",
+        "postgresql+psycopg://postgres:postgres@localhost:5432/mindmap",
+    )
+    connect_args = {}
+    if database_url.startswith("sqlite"):
+        # Allow testing with SQLite while keeping code focused on Postgres.
+        connect_args["check_same_thread"] = False
+    engine = create_engine(database_url, echo=False, future=True, connect_args=connect_args)
+    return engine
+
+
+engine = _build_engine()
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def ensure_schema() -> None:
+    """Ensure the pgvector extension and database schema exist."""
+    from mindmap_api import models  # noqa: F401 - ensure models are registered
+
+    with engine.begin() as connection:
+        # pgvector is required for the embedding column.
+        connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    Base.metadata.create_all(bind=engine)

--- a/mindmap_api/embeddings.py
+++ b/mindmap_api/embeddings.py
@@ -1,0 +1,35 @@
+"""Utility helpers for generating placeholder embeddings."""
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable, List
+
+from mindmap_api.models import VECTOR_DIMENSION
+
+
+def deterministic_embedding(*parts: Iterable[str | None] | str | None) -> List[float]:
+    """Create a deterministic embedding from text parts.
+
+    The function is intentionally simple: it hashes the concatenation of provided
+    strings and maps the hash to a fixed-size vector in the range [-1, 1].
+    This keeps the project self-contained while still leveraging the pgvector
+    column for similarity-friendly storage.
+    """
+
+    flat_parts: list[str] = []
+    for value in parts:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            flat_parts.append(value)
+        else:
+            flat_parts.extend([segment for segment in value if segment is not None])
+    base = "||".join(flat_parts).encode("utf-8")
+    digest = hashlib.sha256(base).digest()
+    # Use the digest to fill the vector
+    vector = []
+    for index in range(VECTOR_DIMENSION):
+        byte = digest[index % len(digest)]
+        normalized = (byte / 255.0) * 2 - 1
+        vector.append(round(normalized, 6))
+    return vector

--- a/mindmap_api/main.py
+++ b/mindmap_api/main.py
@@ -1,0 +1,337 @@
+"""FastAPI entrypoint exposing mind map data backed by PostgreSQL."""
+from __future__ import annotations
+
+from typing import Generator, Iterable
+from uuid import UUID
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, selectinload
+
+from mindmap_api.database import SessionLocal, ensure_schema, session_scope
+from mindmap_api.embeddings import deterministic_embedding
+from mindmap_api import models
+from mindmap_api import schemas
+
+
+app = FastAPI(title="Mind Map Service", version="1.0.0")
+
+
+def get_session() -> Generator[Session, None, None]:
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@app.on_event("startup")
+def startup() -> None:
+    ensure_schema()
+    _bootstrap_sample_data()
+
+
+def _bootstrap_sample_data() -> None:
+    """Create a default mind map if the database is empty."""
+    with session_scope() as session:
+        existing = session.execute(select(func.count(models.MindMap.id))).scalar_one()
+        if existing:
+            return
+
+        mind_map = models.MindMap(
+            title="Онбординг нового разработчика",
+            description=(
+                "Стартовая майнд-карта с ключевыми шагами адаптации сотрудника."
+            ),
+        )
+        session.add(mind_map)
+        session.flush()
+
+        nodes = [
+            models.MindMapNode(
+                mind_map_id=mind_map.id,
+                key="welcome",
+                title="Приветствие",
+                content="Встреча с тимлидом и обзор проекта",
+                position_x=0,
+                position_y=0,
+                embedding=deterministic_embedding("Приветствие", "тимлид"),
+            ),
+            models.MindMapNode(
+                mind_map_id=mind_map.id,
+                key="access",
+                title="Доступы",
+                content="Создание аккаунтов, настройка VPN и репозиториев",
+                position_x=1,
+                position_y=0.5,
+                embedding=deterministic_embedding("Доступы", "VPN"),
+            ),
+            models.MindMapNode(
+                mind_map_id=mind_map.id,
+                key="stack",
+                title="Изучение стека",
+                content="Документация, код-ревью, стандартные практики",
+                position_x=2,
+                position_y=0.2,
+                embedding=deterministic_embedding("стек", "документация"),
+            ),
+            models.MindMapNode(
+                mind_map_id=mind_map.id,
+                key="first-task",
+                title="Первая задача",
+                content="Небольшой тикет для погружения",
+                position_x=3,
+                position_y=0.5,
+                embedding=deterministic_embedding("первая", "задача"),
+            ),
+        ]
+
+        for node in nodes:
+            session.add(node)
+        session.flush()
+        node_index = {node.key: node.id for node in nodes}
+
+        edges = [
+            models.MindMapEdge(
+                mind_map_id=mind_map.id,
+                source_node_id=node_index["welcome"],
+                target_node_id=node_index["access"],
+                relationship="подготовка",
+            ),
+            models.MindMapEdge(
+                mind_map_id=mind_map.id,
+                source_node_id=node_index["access"],
+                target_node_id=node_index["stack"],
+                relationship="развитие",
+            ),
+            models.MindMapEdge(
+                mind_map_id=mind_map.id,
+                source_node_id=node_index["stack"],
+                target_node_id=node_index["first-task"],
+                relationship="применение",
+            ),
+        ]
+
+        for edge in edges:
+            session.add(edge)
+
+        session.add(
+            models.MindMapLog(
+                mind_map_id=mind_map.id,
+                level="info",
+                message="Автоматически созданная майнд-карта для демонстрации",
+                metadata={"source": "bootstrap"},
+            )
+        )
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/mindmaps", response_model=list[schemas.MindMapSummary])
+def list_mindmaps(session: Session = Depends(get_session)) -> list[schemas.MindMapSummary]:
+    mind_maps = (
+        session.execute(
+            select(models.MindMap)
+            .options(
+                selectinload(models.MindMap.nodes),
+                selectinload(models.MindMap.edges),
+            )
+            .order_by(models.MindMap.created_at.desc())
+        )
+        .scalars()
+        .all()
+    )
+    return [
+        schemas.MindMapSummary(
+            id=item.id,
+            title=item.title,
+            description=item.description,
+            node_count=len(item.nodes),
+            edge_count=len(item.edges),
+            created_at=item.created_at,
+            updated_at=item.updated_at,
+        )
+        for item in mind_maps
+    ]
+
+
+@app.get("/mindmaps/{mind_map_id}", response_model=schemas.MindMapDetail)
+def get_mindmap(mind_map_id: UUID, session: Session = Depends(get_session)) -> schemas.MindMapDetail:
+    mind_map = _load_mind_map(session, mind_map_id)
+    if mind_map is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mind map not found")
+    return _serialize_mind_map(mind_map)
+
+
+@app.post("/mindmaps", response_model=schemas.MindMapDetail, status_code=status.HTTP_201_CREATED)
+def create_mindmap(
+    payload: schemas.MindMapCreate,
+    session: Session = Depends(get_session),
+) -> schemas.MindMapDetail:
+    mind_map = models.MindMap(title=payload.title, description=payload.description)
+    session.add(mind_map)
+    session.flush()
+
+    node_index: dict[str, models.MindMapNode] = {}
+
+    try:
+        for node_in in payload.nodes:
+            embedding = node_in.embedding or deterministic_embedding(node_in.title, node_in.content)
+            node = models.MindMapNode(
+                mind_map_id=mind_map.id,
+                key=node_in.key,
+                title=node_in.title,
+                content=node_in.content,
+                position_x=node_in.position.x if node_in.position else None,
+                position_y=node_in.position.y if node_in.position else None,
+                embedding=embedding,
+            )
+            session.add(node)
+            session.flush()
+            node_index[node_in.key] = node
+
+        for edge_in in payload.edges:
+            try:
+                source = node_index[edge_in.source_key]
+                target = node_index[edge_in.target_key]
+            except KeyError as exc:  # pragma: no cover - defensive branch
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Unknown node reference: {exc.args[0]}",
+                ) from exc
+            session.add(
+                models.MindMapEdge(
+                    mind_map_id=mind_map.id,
+                    source_node_id=source.id,
+                    target_node_id=target.id,
+                    relationship=edge_in.relationship,
+                )
+            )
+
+        logs: Iterable[schemas.MindMapLogCreate]
+        if payload.logs:
+            logs = payload.logs
+        else:
+            logs = [
+                schemas.MindMapLogCreate(
+                    level="info",
+                    message="Mind map created",
+                    metadata={"auto": True},
+                )
+            ]
+
+        for log_in in logs:
+            session.add(
+                models.MindMapLog(
+                    mind_map_id=mind_map.id,
+                    level=log_in.level,
+                    message=log_in.message,
+                    metadata=log_in.metadata,
+                )
+            )
+        session.commit()
+    except IntegrityError as exc:
+        session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Mind map contains duplicate keys or invalid references",
+        ) from exc
+
+    reloaded = _load_mind_map(session, mind_map.id)
+    if reloaded is None:  # pragma: no cover - created object must exist
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to load mind map")
+    return _serialize_mind_map(reloaded)
+
+
+@app.post(
+    "/mindmaps/{mind_map_id}/logs",
+    response_model=schemas.MindMapLogResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_log(
+    mind_map_id: UUID,
+    payload: schemas.MindMapLogCreate,
+    session: Session = Depends(get_session),
+) -> schemas.MindMapLogResponse:
+    mind_map = session.get(models.MindMap, mind_map_id)
+    if mind_map is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mind map not found")
+
+    log = models.MindMapLog(
+        mind_map_id=mind_map.id,
+        level=payload.level,
+        message=payload.message,
+        metadata=payload.metadata,
+    )
+    session.add(log)
+    session.commit()
+    session.refresh(log)
+    return schemas.MindMapLogResponse(
+        id=log.id,
+        mind_map_id=log.mind_map_id,
+        level=log.level,
+        message=log.message,
+        metadata=log.metadata,
+        created_at=log.created_at,
+    )
+
+
+def _load_mind_map(session: Session, mind_map_id: UUID) -> models.MindMap | None:
+    return (
+        session.execute(
+            select(models.MindMap)
+            .options(
+                selectinload(models.MindMap.nodes),
+                selectinload(models.MindMap.edges),
+                selectinload(models.MindMap.logs),
+            )
+            .where(models.MindMap.id == mind_map_id)
+        )
+        .scalars()
+        .first()
+    )
+
+
+def _serialize_mind_map(mind_map: models.MindMap) -> schemas.MindMapDetail:
+    return schemas.MindMapDetail(
+        id=mind_map.id,
+        title=mind_map.title,
+        description=mind_map.description,
+        created_at=mind_map.created_at,
+        updated_at=mind_map.updated_at,
+        nodes=[
+            schemas.MindMapNode(
+                id=node.id,
+                key=node.key,
+                title=node.title,
+                content=node.content,
+                position=schemas.MindMapNodePosition(x=node.position_x, y=node.position_y),
+                embedding=list(node.embedding or []),
+                created_at=node.created_at,
+            )
+            for node in mind_map.nodes
+        ],
+        edges=[
+            schemas.MindMapEdge(
+                id=edge.id,
+                source_node_id=edge.source_node_id,
+                target_node_id=edge.target_node_id,
+                relationship=edge.relationship,
+            )
+            for edge in mind_map.edges
+        ],
+        logs=[
+            schemas.MindMapLog(
+                id=log.id,
+                level=log.level,
+                message=log.message,
+                metadata=log.metadata,
+                created_at=log.created_at,
+            )
+            for log in sorted(mind_map.logs, key=lambda item: item.created_at)
+        ],
+    )

--- a/mindmap_api/models.py
+++ b/mindmap_api/models.py
@@ -1,0 +1,121 @@
+"""SQLAlchemy models for the mind map domain."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import JSON, Column, DateTime, Float, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from mindmap_api.database import Base
+
+
+VECTOR_DIMENSION = 8
+
+
+class MindMap(Base):
+    __tablename__ = "mind_maps"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    nodes: Mapped[list["MindMapNode"]] = relationship(
+        "MindMapNode", back_populates="mind_map", cascade="all, delete-orphan"
+    )
+    edges: Mapped[list["MindMapEdge"]] = relationship(
+        "MindMapEdge", back_populates="mind_map", cascade="all, delete-orphan"
+    )
+    logs: Mapped[list["MindMapLog"]] = relationship(
+        "MindMapLog", back_populates="mind_map", cascade="all, delete-orphan"
+    )
+
+
+class MindMapNode(Base):
+    __tablename__ = "mind_map_nodes"
+    __table_args__ = (
+        UniqueConstraint("mind_map_id", "key", name="uq_node_key_per_map"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    mind_map_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mind_maps.id", ondelete="CASCADE"), nullable=False
+    )
+    key: Mapped[str] = mapped_column(String(64), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    content: Mapped[str | None] = mapped_column(Text, nullable=True)
+    position_x: Mapped[float | None] = mapped_column(Float, nullable=True)
+    position_y: Mapped[float | None] = mapped_column(Float, nullable=True)
+    embedding: Mapped[list[float]] = mapped_column(
+        Vector(VECTOR_DIMENSION), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    mind_map: Mapped[MindMap] = relationship("MindMap", back_populates="nodes")
+    outgoing_edges: Mapped[list["MindMapEdge"]] = relationship(
+        "MindMapEdge", back_populates="source", foreign_keys="MindMapEdge.source_node_id"
+    )
+    incoming_edges: Mapped[list["MindMapEdge"]] = relationship(
+        "MindMapEdge", back_populates="target", foreign_keys="MindMapEdge.target_node_id"
+    )
+
+
+class MindMapEdge(Base):
+    __tablename__ = "mind_map_edges"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    mind_map_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mind_maps.id", ondelete="CASCADE"), nullable=False
+    )
+    source_node_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mind_map_nodes.id", ondelete="CASCADE"), nullable=False
+    )
+    target_node_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mind_map_nodes.id", ondelete="CASCADE"), nullable=False
+    )
+    relationship: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    mind_map: Mapped[MindMap] = relationship("MindMap", back_populates="edges")
+    source: Mapped[MindMapNode] = relationship(
+        "MindMapNode", foreign_keys=[source_node_id], back_populates="outgoing_edges"
+    )
+    target: Mapped[MindMapNode] = relationship(
+        "MindMapNode", foreign_keys=[target_node_id], back_populates="incoming_edges"
+    )
+
+
+class MindMapLog(Base):
+    __tablename__ = "mind_map_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    mind_map_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mind_maps.id", ondelete="CASCADE"), nullable=False
+    )
+    level: Mapped[str] = mapped_column(String(32), default="info")
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    metadata = Column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+    mind_map: Mapped[MindMap] = relationship("MindMap", back_populates="logs")

--- a/mindmap_api/requirements.txt
+++ b/mindmap_api/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.115.5
+uvicorn[standard]==0.32.0
+sqlalchemy==2.0.36
+psycopg[binary]==3.2.3
+pgvector==0.2.5
+python-dotenv==1.0.1

--- a/mindmap_api/schemas.py
+++ b/mindmap_api/schemas.py
@@ -1,0 +1,102 @@
+"""Pydantic schemas for the mind map API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, List
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class MindMapNodePosition(BaseModel):
+    x: float | None = Field(default=None, description="Canvas X coordinate")
+    y: float | None = Field(default=None, description="Canvas Y coordinate")
+
+
+class MindMapNodeCreate(BaseModel):
+    key: str = Field(..., description="Stable node identifier used when creating edges")
+    title: str
+    content: str | None = None
+    position: MindMapNodePosition | None = None
+    embedding: List[float] | None = Field(
+        default=None, description="Optional embedding vector for the node"
+    )
+
+
+class MindMapEdgeCreate(BaseModel):
+    source_key: str = Field(..., description="Key of the parent/source node")
+    target_key: str = Field(..., description="Key of the child/target node")
+    relationship: str | None = Field(
+        default=None, description="Optional label describing the relationship"
+    )
+
+
+class MindMapLogCreate(BaseModel):
+    message: str
+    level: str = Field(default="info")
+    metadata: dict[str, Any] | None = None
+
+
+class MindMapCreate(BaseModel):
+    title: str
+    description: str | None = None
+    nodes: list[MindMapNodeCreate]
+    edges: list[MindMapEdgeCreate]
+    logs: list[MindMapLogCreate] | None = None
+
+
+class MindMapSummary(BaseModel):
+    id: UUID
+    title: str
+    description: str | None = None
+    node_count: int
+    edge_count: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = dict(from_attributes=True)
+
+
+class MindMapNode(BaseModel):
+    id: UUID
+    key: str
+    title: str
+    content: str | None = None
+    position: MindMapNodePosition
+    embedding: List[float]
+    created_at: datetime
+
+
+class MindMapEdge(BaseModel):
+    id: UUID
+    source_node_id: UUID
+    target_node_id: UUID
+    relationship: str | None = None
+
+
+class MindMapLog(BaseModel):
+    id: UUID
+    level: str
+    message: str
+    metadata: dict[str, Any] | None
+    created_at: datetime
+
+
+class MindMapDetail(BaseModel):
+    id: UUID
+    title: str
+    description: str | None
+    created_at: datetime
+    updated_at: datetime
+    nodes: list[MindMapNode]
+    edges: list[MindMapEdge]
+    logs: list[MindMapLog]
+
+
+class MindMapLogResponse(BaseModel):
+    id: UUID
+    mind_map_id: UUID
+    level: str
+    message: str
+    metadata: dict[str, Any] | None
+    created_at: datetime

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",
+    "mindmap:api": "uvicorn mindmap_api.main:app --reload",
     "task": "node scripts/task.js",
     "task:clean": "node scripts/task-clean.js"
   },

--- a/src/app/mind-map/page.tsx
+++ b/src/app/mind-map/page.tsx
@@ -1,0 +1,70 @@
+import Link from 'next/link'
+import MindMapViewer from '@/components/mindmap/MindMapViewer'
+import type { MindMapDetail, MindMapSummary } from '@/components/mindmap/types'
+
+export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-no-store'
+
+const API_FALLBACK_URL = 'http://localhost:8000'
+
+async function fetchSummaries(baseUrl: string): Promise<MindMapSummary[]> {
+  try {
+    const response = await fetch(`${baseUrl}/mindmaps`, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    })
+    if (!response.ok) {
+      console.warn('Mind map API responded with status', response.status)
+      return []
+    }
+    return (await response.json()) as MindMapSummary[]
+  } catch (error) {
+    console.warn('Failed to fetch mind maps', error)
+    return []
+  }
+}
+
+async function fetchInitialDetail(baseUrl: string, mindMapId: string): Promise<MindMapDetail | null> {
+  try {
+    const response = await fetch(`${baseUrl}/mindmaps/${mindMapId}`, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+    })
+    if (!response.ok) return null
+    return (await response.json()) as MindMapDetail
+  } catch (error) {
+    console.warn('Failed to fetch mind map detail', error)
+    return null
+  }
+}
+
+export default async function MindMapPage() {
+  const apiBaseUrl = process.env.MINDMAP_API_URL ?? API_FALLBACK_URL
+  const summaries = await fetchSummaries(apiBaseUrl)
+  const firstId = summaries[0]?.id
+  const initialDetail = firstId ? await fetchInitialDetail(apiBaseUrl, firstId) : null
+
+  return (
+    <main className="min-h-screen bg-canvas-light">
+      <div className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.2em] text-slate-500">Визуализация</p>
+            <h1 className="mt-1 text-3xl font-semibold text-slate-900">Mind Map из PostgreSQL</h1>
+            <p className="mt-2 max-w-2xl text-sm text-slate-600">
+              Страница использует FastAPI-сервис, который хранит структуру майнд-карты и логи в PostgreSQL с расширением pgvector.
+            </p>
+          </div>
+          <Link
+            href="/"
+            className="inline-flex items-center justify-center rounded-2xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+          >
+            Назад к задачам
+          </Link>
+        </div>
+
+        <MindMapViewer initialSummaries={summaries} apiBaseUrl={apiBaseUrl} initialDetail={initialDetail} />
+      </div>
+    </main>
+  )
+}

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -13,6 +13,7 @@ import { PinnedList } from './PinnedList'
 import { PinnedTextView } from './PinnedTextView'
 import { TodoItem } from './TodoItem'
 import { TodoSearchBar } from './TodoSearchBar'
+import Link from 'next/link'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 
 interface TodoAppProps {
@@ -145,7 +146,7 @@ const TodoAppContent = () => {
     <div className="min-h-screen bg-canvas-light text-slate-900">
       <div className="mx-auto flex min-h-screen max-w-4xl flex-col px-4 py-10 sm:px-6 lg:px-8">
         <section className="flex-1 rounded-3xl bg-white/60 p-5 shadow-inner ring-1 ring-white/40">
-          <div className="mb-6 flex items-center justify-between gap-3">
+          <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
             <div className="flex rounded-2xl bg-white/70 p-1 text-sm font-medium text-slate-500 shadow-sm ring-1 ring-slate-200/70">
               {tabs.map((tab) => (
                 <button
@@ -163,17 +164,25 @@ const TodoAppContent = () => {
                 </button>
               ))}
             </div>
-            {activeTab === 'all' && (
-              <button
-                type="button"
-                onClick={openAddModal}
-                className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
-                aria-label="Добавить задачу"
+            <div className="flex items-center gap-3">
+              <Link
+                href="/mind-map"
+                className="inline-flex items-center gap-2 rounded-xl border border-transparent bg-slate-100 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white"
               >
-                <FiPlus />
-                Добавить
-              </button>
-            )}
+                Mind Map
+              </Link>
+              {activeTab === 'all' && (
+                <button
+                  type="button"
+                  onClick={openAddModal}
+                  className="flex items-center justify-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800"
+                  aria-label="Добавить задачу"
+                >
+                  <FiPlus />
+                  Добавить
+                </button>
+              )}
+            </div>
           </div>
 
           {activeTab === 'pinned' ? (

--- a/src/components/mindmap/MindMapViewer.tsx
+++ b/src/components/mindmap/MindMapViewer.tsx
@@ -1,0 +1,316 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+
+import type {
+  MindMapDetail,
+  MindMapNode,
+  MindMapSummary,
+} from './types'
+
+interface MindMapViewerProps {
+  initialSummaries: MindMapSummary[]
+  apiBaseUrl: string
+  initialDetail: MindMapDetail | null
+}
+
+type Levels = MindMapNode[][]
+
+type ChildMap = Map<string, MindMapNode[]>
+
+const formatDateTime = (value: string) => {
+  const date = new Date(value)
+  return new Intl.DateTimeFormat('ru-RU', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(date)
+}
+
+const formatEmbedding = (embedding: number[]) =>
+  embedding.map((value) => value.toFixed(2)).join(' · ')
+
+export const MindMapViewer = ({
+  initialSummaries,
+  apiBaseUrl,
+  initialDetail,
+}: MindMapViewerProps) => {
+  const [selectedId, setSelectedId] = useState<string | null>(
+    initialDetail?.id ?? initialSummaries[0]?.id ?? null,
+  )
+  const [detail, setDetail] = useState<MindMapDetail | null>(initialDetail)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null)
+      return
+    }
+    if (detail?.id === selectedId) {
+      return
+    }
+
+    const controller = new AbortController()
+    const load = async () => {
+      try {
+        setIsLoading(true)
+        setError(null)
+        const response = await fetch(`${apiBaseUrl}/mindmaps/${selectedId}`, {
+          signal: controller.signal,
+          headers: { Accept: 'application/json' },
+        })
+        if (!response.ok) {
+          throw new Error(`Ошибка загрузки: ${response.status}`)
+        }
+        const payload = (await response.json()) as MindMapDetail
+        setDetail(payload)
+      } catch (err) {
+        if ((err as Error).name === 'AbortError') return
+        console.error(err)
+        setError('Не удалось получить майнд-карту. Проверьте работу сервера FastAPI.')
+        setDetail(null)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    void load()
+
+    return () => {
+      controller.abort()
+    }
+  }, [selectedId, apiBaseUrl, detail?.id])
+
+  const { levels, childMap } = useMemo(() => {
+    if (!detail) {
+      return { levels: [] as Levels, childMap: new Map() as ChildMap }
+    }
+    const nodesById = new Map(detail.nodes.map((node) => [node.id, node]))
+    const incomingCount = new Map<string, number>()
+    const adjacency = new Map<string, MindMapNode[]>()
+
+    for (const node of detail.nodes) {
+      incomingCount.set(node.id, 0)
+      adjacency.set(node.id, [])
+    }
+
+    for (const edge of detail.edges) {
+      const target = nodesById.get(edge.target_node_id)
+      const source = nodesById.get(edge.source_node_id)
+      if (!target || !source) continue
+      incomingCount.set(target.id, (incomingCount.get(target.id) ?? 0) + 1)
+      adjacency.get(source.id)?.push(target)
+    }
+
+    const roots = detail.nodes.filter((node) => (incomingCount.get(node.id) ?? 0) === 0)
+    const queue = [...roots]
+    const depthByNode = new Map<string, number>()
+
+    for (const root of roots) {
+      depthByNode.set(root.id, 0)
+    }
+
+    while (queue.length > 0) {
+      const current = queue.shift()!
+      const currentDepth = depthByNode.get(current.id) ?? 0
+      const children = adjacency.get(current.id) ?? []
+      for (const child of children) {
+        const nextDepth = currentDepth + 1
+        if (!depthByNode.has(child.id) || nextDepth < (depthByNode.get(child.id) ?? 0)) {
+          depthByNode.set(child.id, nextDepth)
+          queue.push(child)
+        }
+      }
+    }
+
+    // Fallback for nodes participating in cycles
+    for (const node of detail.nodes) {
+      if (!depthByNode.has(node.id)) {
+        depthByNode.set(node.id, 0)
+      }
+    }
+
+    if (depthByNode.size === 0) {
+      return { levels: [[]], childMap: adjacency }
+    }
+
+    const maxDepth = Math.max(...depthByNode.values())
+    const computedLevels: Levels = Array.from({ length: maxDepth + 1 }, () => [])
+
+    for (const node of detail.nodes) {
+      const level = depthByNode.get(node.id) ?? 0
+      computedLevels[level].push(node)
+    }
+
+    for (const column of computedLevels) {
+      column.sort((a, b) => a.title.localeCompare(b.title, 'ru'))
+    }
+
+    return { levels: computedLevels, childMap: adjacency }
+  }, [detail])
+
+  if (!initialSummaries.length) {
+    return (
+      <div className="rounded-3xl border border-dashed border-slate-300 bg-white/40 p-10 text-center text-slate-500">
+        Нет доступных майнд-карт. Создайте новую через FastAPI.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white/70 p-5 shadow-sm md:flex-row md:items-center md:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-slate-500">Выберите карту</p>
+          <h2 className="text-xl font-semibold text-slate-900">{detail?.title ?? 'Загрузка...'}</h2>
+          {detail?.description && (
+            <p className="mt-1 text-sm text-slate-600">{detail.description}</p>
+          )}
+        </div>
+        <div className="flex w-full flex-col gap-2 md:w-72">
+          <label className="text-xs font-medium uppercase tracking-wide text-slate-500" htmlFor="mindmap-select">
+            Доступные карты
+          </label>
+          <select
+            id="mindmap-select"
+            value={selectedId ?? ''}
+            onChange={(event) => setSelectedId(event.target.value || null)}
+            className="w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 shadow-inner focus:border-slate-500 focus:outline-none"
+          >
+            {initialSummaries.map((summary) => (
+              <option key={summary.id} value={summary.id}>
+                {summary.title} ({summary.node_count} нод)
+              </option>
+            ))}
+          </select>
+          {error && <p className="text-sm text-rose-600">{error}</p>}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-6 lg:flex-row">
+        <section className="flex-1 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+          <header className="mb-5 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h3 className="text-base font-semibold text-slate-800">Структура карты</h3>
+              <p className="text-xs text-slate-500">
+                Всего {detail?.nodes.length ?? 0} нод · {detail?.edges.length ?? 0} связей
+              </p>
+            </div>
+            {detail && (
+              <p className="text-xs text-slate-500">
+                Обновлено {formatDateTime(detail.updated_at)}
+              </p>
+            )}
+          </header>
+
+          {isLoading && (
+            <div className="mb-4 rounded-2xl border border-slate-100 bg-slate-50 p-6 text-sm text-slate-500">
+              Загрузка данных из FastAPI...
+            </div>
+          )}
+
+          {detail ? (
+            <div
+              className="grid gap-4 md:gap-6"
+              style={{ gridTemplateColumns: `repeat(${Math.max(levels.length, 1)}, minmax(0, 1fr))` }}
+            >
+              {levels.map((column, index) => (
+                <div key={index} className="space-y-4">
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Уровень {index + 1}
+                  </p>
+                  {column.map((node) => {
+                    const children = childMap.get(node.id) ?? []
+                    return (
+                      <article
+                        key={node.id}
+                        className="group rounded-2xl border border-slate-200 bg-white/90 p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md"
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <h4 className="text-lg font-semibold text-slate-900">{node.title}</h4>
+                          <span className="rounded-full bg-slate-900/80 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+                            {node.key}
+                          </span>
+                        </div>
+                        {node.content && (
+                          <p className="mt-3 text-sm leading-relaxed text-slate-600">{node.content}</p>
+                        )}
+                        <dl className="mt-4 space-y-2 text-xs text-slate-500">
+                          <div className="flex items-center justify-between gap-3">
+                            <dt className="font-medium text-slate-600">Координаты</dt>
+                            <dd className="font-mono text-slate-500">
+                              x: {node.position.x ?? '—'} · y: {node.position.y ?? '—'}
+                            </dd>
+                          </div>
+                          <div>
+                            <dt className="font-medium text-slate-600">Embedding</dt>
+                            <dd className="mt-1 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[11px] text-slate-500">
+                              {formatEmbedding(node.embedding)}
+                            </dd>
+                          </div>
+                        </dl>
+                        {children.length > 0 && (
+                          <div className="mt-4 rounded-xl bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                            <p className="font-semibold text-slate-500">Дочерние ноды</p>
+                            <ul className="mt-2 space-y-1">
+                              {children.map((child) => (
+                                <li key={child.id} className="flex items-center justify-between gap-2">
+                                  <span>{child.title}</span>
+                                  <span className="rounded-full bg-slate-200 px-2 py-0.5 text-[10px] font-semibold uppercase text-slate-600">
+                                    {child.key}
+                                  </span>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
+                      </article>
+                    )
+                  })}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-slate-300 p-10 text-center text-sm text-slate-500">
+              Выберите карту, чтобы увидеть её структуру.
+            </div>
+          )}
+        </section>
+
+        <aside className="lg:w-80">
+          <div className="h-full rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-sm">
+            <h3 className="text-base font-semibold text-slate-800">Логи создания</h3>
+            <p className="text-xs text-slate-500">Записи фиксируются в PostgreSQL вместе с картой.</p>
+            <div className="mt-4 space-y-3 overflow-y-auto pr-1" style={{ maxHeight: '32rem' }}>
+              {detail?.logs.map((log) => (
+                <article key={log.id} className="rounded-2xl border border-slate-100 bg-slate-50 p-4 text-sm text-slate-700">
+                  <div className="mb-2 flex items-center justify-between text-xs font-semibold uppercase text-slate-500">
+                    <span className="rounded-full bg-slate-900/80 px-2 py-0.5 text-[10px] tracking-wide text-white">
+                      {log.level}
+                    </span>
+                    <time dateTime={log.created_at} className="text-slate-400">
+                      {formatDateTime(log.created_at)}
+                    </time>
+                  </div>
+                  <p>{log.message}</p>
+                  {log.metadata && (
+                    <pre className="mt-2 overflow-x-auto rounded-lg bg-white/70 p-2 text-xs text-slate-600">
+                      {JSON.stringify(log.metadata, null, 2)}
+                    </pre>
+                  )}
+                </article>
+              ))}
+              {!detail && (
+                <p className="rounded-2xl border border-dashed border-slate-300 p-4 text-center text-xs text-slate-500">
+                  Логи появятся после выбора карты.
+                </p>
+              )}
+            </div>
+          </div>
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+export default MindMapViewer

--- a/src/components/mindmap/types.ts
+++ b/src/components/mindmap/types.ts
@@ -1,0 +1,48 @@
+export interface MindMapSummary {
+  id: string
+  title: string
+  description?: string | null
+  node_count: number
+  edge_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface MindMapNode {
+  id: string
+  key: string
+  title: string
+  content?: string | null
+  position: {
+    x: number | null
+    y: number | null
+  }
+  embedding: number[]
+  created_at: string
+}
+
+export interface MindMapEdge {
+  id: string
+  source_node_id: string
+  target_node_id: string
+  relationship?: string | null
+}
+
+export interface MindMapLog {
+  id: string
+  level: string
+  message: string
+  metadata?: Record<string, unknown> | null
+  created_at: string
+}
+
+export interface MindMapDetail {
+  id: string
+  title: string
+  description?: string | null
+  created_at: string
+  updated_at: string
+  nodes: MindMapNode[]
+  edges: MindMapEdge[]
+  logs: MindMapLog[]
+}


### PR DESCRIPTION
## Summary
- add a FastAPI service backed by PostgreSQL + pgvector for storing mind map nodes, edges, and creation logs
- add a Tailwind-styled mind map viewer page and navigation link in the Next.js UI
- document setup, environment variables, and scripts for running the new backend service

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68fa236d53188324a8dde1794d6cb97e