### PR TITLE
Add FastAPI mind map service backed by PostgreSQL pgvector

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,37 @@
 - Tailwind CSS для стилизации;
 - HTML5 drag-and-drop.
 
+## FastAPI сервер mind map
+
+В репозитории добавлен отдельный Python-сервис на FastAPI для просмотра mind map с
+данными из PostgreSQL и расширением `pgvector`.
+
+### Быстрый старт
+
+```bash
+# Установите Python-зависимости
+python -m venv .venv
+source .venv/bin/activate
+pip install -r backend/requirements.txt
+
+# Настройте подключение к PostgreSQL (расширение pgvector должно быть доступно)
+export MINDMAP_DATABASE_URL="postgresql://user:pass@localhost:5432/mindmap"
+
+# Запустите сервер
+uvicorn backend.main:app --reload
+```
+
+Сервис автоматически создаёт расширение `vector` и необходимые таблицы (ноды,
+связи и журнал событий). Интерфейс доступен на `http://127.0.0.1:8000/` —
+страница использует TailwindCSS и визуализирует mind map в браузере на основе
+актуальных данных из БД.
+
+### API
+
+- `GET /api/mind-map` — получить список нод, связей и последних логов;
+- `POST /api/mind-map` — синхронизировать mind map в базе (ноды, связи, логи);
+- `GET /api/mind-map/logs` — получить последние записи журнала.
+
 ## Быстрый старт
 
 ```bash

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,9 @@
+"""Backend package for the FastAPI mind map server."""
+
+__all__ = [
+    "crud",
+    "db",
+    "main",
+    "models",
+    "schemas",
+]

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,0 +1,136 @@
+"""Database helpers for the mind map FastAPI service."""
+from __future__ import annotations
+
+from typing import Iterable, List
+from uuid import UUID, uuid4
+
+from sqlalchemy import delete, not_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import MindMapEdge, MindMapLog, MindMapNode
+from .schemas import (
+    EdgeCreate,
+    EdgeOut,
+    LogCreate,
+    LogOut,
+    MindMapResponse,
+    MindMapUpsert,
+    NodeCreate,
+    NodeOut,
+)
+
+
+async def _load_nodes(session: AsyncSession) -> List[MindMapNode]:
+    result = await session.execute(select(MindMapNode).order_by(MindMapNode.created_at))
+    return list(result.scalars().all())
+
+
+async def _load_edges(session: AsyncSession) -> List[MindMapEdge]:
+    result = await session.execute(select(MindMapEdge).order_by(MindMapEdge.created_at))
+    return list(result.scalars().all())
+
+
+async def _load_logs(session: AsyncSession, limit: int | None = None) -> List[MindMapLog]:
+    stmt = select(MindMapLog).order_by(MindMapLog.created_at.desc())
+    if limit is not None:
+        stmt = stmt.limit(limit)
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_recent_logs(session: AsyncSession, limit: int = 50) -> List[LogOut]:
+    logs = await _load_logs(session, limit)
+    return [LogOut.model_validate(log) for log in logs]
+
+
+async def get_mind_map(session: AsyncSession) -> MindMapResponse:
+    nodes = await _load_nodes(session)
+    edges = await _load_edges(session)
+    logs = await _load_logs(session, limit=50)
+    return MindMapResponse(
+        nodes=[NodeOut.model_validate(node) for node in nodes],
+        edges=[EdgeOut.model_validate(edge) for edge in edges],
+        logs=[LogOut.model_validate(log) for log in logs],
+    )
+
+
+async def _upsert_node(session: AsyncSession, data: NodeCreate) -> MindMapNode:
+    node_id = data.id or uuid4()
+    existing = await session.get(MindMapNode, node_id)
+    if existing:
+        existing.title = data.title
+        existing.content = data.content
+        existing.embedding = data.embedding
+        return existing
+    node = MindMapNode(
+        id=node_id,
+        title=data.title,
+        content=data.content,
+        embedding=data.embedding,
+    )
+    session.add(node)
+    return node
+
+
+async def _replace_edges(session: AsyncSession, edges: Iterable[EdgeCreate]) -> None:
+    await session.execute(delete(MindMapEdge))
+    for edge in edges:
+        session.add(
+            MindMapEdge(
+                source_id=edge.source_id,
+                target_id=edge.target_id,
+                label=edge.label,
+            )
+        )
+
+
+async def _sync_nodes(session: AsyncSession, nodes: List[NodeCreate]) -> List[MindMapNode]:
+    seen_ids: set[UUID] = set()
+    persisted: List[MindMapNode] = []
+
+    for node_data in nodes:
+        node = await _upsert_node(session, node_data)
+        seen_ids.add(node.id)
+        persisted.append(node)
+
+    if seen_ids:
+        await session.execute(
+            delete(MindMapNode).where(not_(MindMapNode.id.in_(seen_ids)))
+        )
+    else:
+        await session.execute(delete(MindMapNode))
+
+    return persisted
+
+
+async def _create_logs(session: AsyncSession, entries: Iterable[LogCreate]) -> None:
+    for entry in entries:
+        session.add(
+            MindMapLog(
+                level=entry.level,
+                message=entry.message,
+                metadata=entry.metadata,
+            )
+        )
+
+
+async def upsert_mind_map(session: AsyncSession, payload: MindMapUpsert) -> MindMapResponse:
+    persisted_nodes = await _sync_nodes(session, payload.nodes)
+    await _replace_edges(session, payload.edges)
+    await _create_logs(session, payload.logs)
+
+    # Create an automatic log entry describing the update
+    session.add(
+        MindMapLog(
+            level="info",
+            message=f"Mind map synchronised with {len(persisted_nodes)} nodes and {len(payload.edges)} edges.",
+            metadata={
+                "node_ids": [str(node.id) for node in persisted_nodes],
+                "edge_count": len(payload.edges),
+            },
+        )
+    )
+
+    await session.commit()
+
+    return await get_mind_map(session)

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,72 @@
+"""Database configuration for the FastAPI mind map service."""
+from __future__ import annotations
+
+import os
+from typing import AsyncGenerator
+
+from dotenv import load_dotenv
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+load_dotenv()
+
+DATABASE_URL_ENV_KEYS = (
+    "MINDMAP_DATABASE_URL",
+    "DATABASE_URL",
+)
+
+
+def _get_database_url() -> str:
+    for key in DATABASE_URL_ENV_KEYS:
+        value = os.getenv(key)
+        if value:
+            return value
+    raise RuntimeError(
+        "Database URL is not configured. Set MINDMAP_DATABASE_URL or DATABASE_URL."
+    )
+
+
+def _build_async_url(raw_url: str) -> str:
+    if raw_url.startswith("postgresql+asyncpg://"):
+        return raw_url
+    if raw_url.startswith("postgresql://"):
+        return raw_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    if raw_url.startswith("postgres://"):
+        return raw_url.replace("postgres://", "postgresql+asyncpg://", 1)
+    raise ValueError(
+        "Unsupported database URL. Use a PostgreSQL connection string, e.g. postgresql://user:pass@host/db."
+    )
+
+
+DATABASE_URL = _build_async_url(_get_database_url())
+
+
+class Base(DeclarativeBase):
+    """Base class for ORM models."""
+
+
+engine = create_async_engine(
+    DATABASE_URL,
+    future=True,
+    echo=os.getenv("SQL_ECHO", "").lower() in {"1", "true", "yes"},
+)
+
+AsyncSessionMaker = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Dependency that provides a database session."""
+    async with AsyncSessionMaker() as session:
+        yield session
+
+
+async def init_db() -> None:
+    """Initialise the database schema and ensure pgvector is available."""
+    from sqlalchemy import text
+
+    # Import models so they are registered with SQLAlchemy's metadata
+    from . import models  # noqa: F401  # pylint: disable=unused-import
+
+    async with engine.begin() as conn:
+        await conn.execute(text('CREATE EXTENSION IF NOT EXISTS "vector";'))
+        await conn.run_sync(Base.metadata.create_all)

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,73 @@
+"""FastAPI application that exposes mind map data stored in PostgreSQL."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from . import crud
+from .db import get_session, init_db
+from .schemas import LogOut, MindMapResponse, MindMapUpsert
+
+BASE_DIR = Path(__file__).resolve().parent
+
+app = FastAPI(title="Mind Map Viewer", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    await init_db()
+
+
+@app.get("/", response_class=HTMLResponse)
+async def render_mind_map(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+) -> HTMLResponse:
+    logs = await crud.get_recent_logs(session, limit=20)
+    return templates.TemplateResponse(
+        "mind_map.html",
+        {
+            "request": request,
+            "logs": logs,
+        },
+    )
+
+
+@app.get("/api/mind-map", response_model=MindMapResponse)
+async def get_mind_map_api(
+    session: AsyncSession = Depends(get_session),
+) -> MindMapResponse:
+    return await crud.get_mind_map(session)
+
+
+@app.post("/api/mind-map", response_model=MindMapResponse, status_code=201)
+async def upsert_mind_map_api(
+    payload: MindMapUpsert,
+    session: AsyncSession = Depends(get_session),
+) -> MindMapResponse:
+    try:
+        return await crud.upsert_mind_map(session, payload)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/api/mind-map/logs", response_model=list[LogOut])
+async def get_logs_api(
+    session: AsyncSession = Depends(get_session),
+    limit: int = Query(50, ge=1, le=200),
+) -> list[LogOut]:
+    return await crud.get_recent_logs(session, limit)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,65 @@
+"""SQLAlchemy models for the mind map domain."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .db import Base
+
+
+class TimestampMixin:
+    """Reusable timestamp columns."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class MindMapNode(TimestampMixin, Base):
+    """Node that represents a topic in the mind map."""
+
+    __tablename__ = "mind_map_nodes"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    title: Mapped[str] = mapped_column(String(255))
+    content: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    embedding: Mapped[list[float]] = mapped_column(Vector(3))
+
+
+class MindMapEdge(TimestampMixin, Base):
+    """Directed link between two nodes in the mind map."""
+
+    __tablename__ = "mind_map_edges"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    source_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mind_map_nodes.id", ondelete="CASCADE")
+    )
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("mind_map_nodes.id", ondelete="CASCADE")
+    )
+    label: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+
+
+class MindMapLog(TimestampMixin, Base):
+    """Audit trail for mind map creation and updates."""
+
+    __tablename__ = "mind_map_logs"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    level: Mapped[str] = mapped_column(String(32), default="info")
+    message: Mapped[str] = mapped_column(Text)
+    metadata: Mapped[dict | None] = mapped_column(JSON, default=None)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.115.5
+uvicorn[standard]==0.32.0
+sqlalchemy==2.0.36
+asyncpg==0.30.0
+pgvector==0.3.4
+jinja2==3.1.4
+python-dotenv==1.0.1

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,91 @@
+"""Pydantic models for the mind map API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+
+VECTOR_DIMENSION = 3
+
+
+class NodeBase(BaseModel):
+    title: str = Field(..., max_length=255)
+    content: Optional[str] = None
+    embedding: List[float] = Field(
+        ...,
+        min_length=VECTOR_DIMENSION,
+        max_length=VECTOR_DIMENSION,
+        description="Embedding stored in the pgvector column.",
+    )
+
+    @field_validator("embedding")
+    @classmethod
+    def validate_embedding_length(cls, value: List[float]) -> List[float]:
+        if len(value) != VECTOR_DIMENSION:
+            raise ValueError(f"Embedding must contain {VECTOR_DIMENSION} floats.")
+        return value
+
+
+class NodeCreate(NodeBase):
+    id: Optional[UUID] = None
+
+
+class NodeOut(NodeBase):
+    id: UUID
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {
+        "from_attributes": True,
+    }
+
+
+class EdgeBase(BaseModel):
+    source_id: UUID
+    target_id: UUID
+    label: Optional[str] = Field(default=None, max_length=255)
+
+
+class EdgeCreate(EdgeBase):
+    pass
+
+
+class EdgeOut(EdgeBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {
+        "from_attributes": True,
+    }
+
+
+class LogCreate(BaseModel):
+    level: str = Field(default="info", max_length=32)
+    message: str = Field(..., min_length=1)
+    metadata: Dict[str, Any] | None = None
+
+
+class LogOut(LogCreate):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {
+        "from_attributes": True,
+    }
+
+
+class MindMapUpsert(BaseModel):
+    nodes: List[NodeCreate]
+    edges: List[EdgeCreate]
+    logs: List[LogCreate] = Field(default_factory=list)
+
+
+class MindMapResponse(BaseModel):
+    nodes: List[NodeOut]
+    edges: List[EdgeOut]
+    logs: List[LogOut]

--- a/backend/templates/mind_map.html
+++ b/backend/templates/mind_map.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mind Map Viewer</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.14/dist/tailwind.min.css"
+      rel="stylesheet"
+    />
+    <script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+  </head>
+  <body class="bg-slate-950 text-slate-100 min-h-screen">
+    <div class="max-w-7xl mx-auto px-6 py-10 space-y-8">
+      <header class="space-y-2">
+        <p class="text-sky-400 font-semibold uppercase tracking-wide text-xs">
+          FastAPI · PostgreSQL · pgvector
+        </p>
+        <h1 class="text-3xl font-bold">Mind Map Viewer</h1>
+        <p class="text-slate-400 max-w-3xl">
+          Отображает актуальные данные mind map непосредственно из PostgreSQL с
+          расширением <span class="font-mono">pgvector</span>. На странице
+          используется TailwindCSS и визуализация обновляется в реальном времени.
+        </p>
+      </header>
+
+      <section class="grid grid-cols-1 lg:grid-cols-4 gap-6 items-start">
+        <div class="lg:col-span-3">
+          <div
+            id="mind-map"
+            class="h-[600px] rounded-xl border border-slate-800 bg-slate-900/70 shadow-lg shadow-slate-900/40"
+          ></div>
+          <div
+            id="empty-state"
+            class="hidden mt-4 rounded-lg border border-dashed border-slate-700 bg-slate-900/50 p-6 text-center text-slate-300"
+          >
+            <h2 class="text-lg font-semibold text-slate-100">Нет данных</h2>
+            <p class="mt-2 text-sm">
+              Mind map пока пустая. Отправьте данные на <code class="font-mono">POST /api/mind-map</code>,
+              чтобы увидеть визуализацию.
+            </p>
+          </div>
+        </div>
+        <aside class="space-y-4">
+          <div class="rounded-xl border border-slate-800 bg-slate-900/70 p-5">
+            <div class="flex items-center justify-between">
+              <h2 class="text-xl font-semibold">Журнал событий</h2>
+              <span class="rounded-full bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-300">Live</span>
+            </div>
+            <p class="mt-2 text-sm text-slate-400">
+              История создания и обновления mind map. Список обновляется автоматически.
+            </p>
+            <ul id="log-list" class="mt-4 space-y-3 text-sm">
+              {% for log in logs %}
+              <li class="rounded-lg border border-slate-800 bg-slate-950/50 p-3">
+                <div class="flex items-center justify-between text-xs uppercase tracking-wider">
+                  <span class="font-semibold text-sky-400">{{ log.level }}</span>
+                  <time class="text-slate-500">{{ log.created_at.strftime('%Y-%m-%d %H:%M:%S') }}</time>
+                </div>
+                <p class="mt-2 text-slate-200">{{ log.message }}</p>
+                {% if log.metadata %}
+                <pre class="mt-2 overflow-x-auto rounded bg-slate-900/80 p-2 text-xs text-slate-400">{{ log.metadata | tojson(indent=2) }}</pre>
+                {% endif %}
+              </li>
+              {% endfor %}
+            </ul>
+          </div>
+          <div class="rounded-xl border border-slate-800 bg-slate-900/70 p-5 text-sm text-slate-300">
+            <h3 class="text-lg font-semibold text-slate-100">API</h3>
+            <p class="mt-2">
+              <span class="font-mono text-sky-300">GET /api/mind-map</span> — список нод, связей и журналов.
+            </p>
+            <p class="mt-2">
+              <span class="font-mono text-sky-300">POST /api/mind-map</span> — синхронизация данных mind map.
+            </p>
+            <p class="mt-2">
+              <span class="font-mono text-sky-300">GET /api/mind-map/logs</span> — последние события.
+            </p>
+          </div>
+        </aside>
+      </section>
+    </div>
+
+    <script>
+      const networkContainer = document.getElementById("mind-map");
+      const emptyState = document.getElementById("empty-state");
+      const logList = document.getElementById("log-list");
+      let networkInstance = null;
+
+      const networkOptions = {
+        physics: {
+          stabilization: true,
+          barnesHut: {
+            gravitationalConstant: -8000,
+            centralGravity: 0.3,
+            springLength: 120,
+            springConstant: 0.05,
+          },
+        },
+        edges: {
+          smooth: true,
+          color: { color: "#94a3b8" },
+          arrows: {
+            to: { enabled: true, scaleFactor: 0.7 },
+          },
+          font: { color: "#cbd5f5" },
+        },
+        nodes: {
+          shape: "dot",
+          size: 18,
+          font: { color: "#f8fafc", face: "Inter" },
+          borderWidth: 2,
+          color: {
+            border: "#38bdf8",
+            background: "#0f172a",
+            highlight: {
+              border: "#38bdf8",
+              background: "#082f49",
+            },
+          },
+        },
+        layout: {
+          improvedLayout: true,
+        },
+        interaction: {
+          hover: true,
+          tooltipDelay: 200,
+          zoomView: true,
+        },
+      };
+
+      function renderMindMap(data) {
+        if (!data.nodes.length) {
+          emptyState.classList.remove("hidden");
+          if (networkInstance) {
+            networkInstance.setData({ nodes: new vis.DataSet([]), edges: new vis.DataSet([]) });
+          }
+          return;
+        }
+
+        emptyState.classList.add("hidden");
+
+        const nodes = new vis.DataSet(
+          data.nodes.map((node) => ({
+            id: node.id,
+            label: node.title,
+            title:
+              (node.content || "") +
+              (node.embedding?.length ? `\nembedding: [${node.embedding.map((v) => v.toFixed(3)).join(", ")}]` : ""),
+            value: 1,
+          }))
+        );
+
+        const edges = new vis.DataSet(
+          data.edges.map((edge) => ({
+            id: edge.id,
+            from: edge.source_id,
+            to: edge.target_id,
+            label: edge.label || "",
+          }))
+        );
+
+        if (!networkInstance) {
+          networkInstance = new vis.Network(
+            networkContainer,
+            { nodes, edges },
+            networkOptions
+          );
+        } else {
+          networkInstance.setData({ nodes, edges });
+        }
+      }
+
+      async function refreshMindMap() {
+        try {
+          const response = await fetch("/api/mind-map");
+          if (!response.ok) {
+            throw new Error("Не удалось загрузить данные mind map");
+          }
+          const payload = await response.json();
+          renderMindMap(payload);
+          renderLogs(payload.logs);
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      async function refreshLogs() {
+        try {
+          const response = await fetch("/api/mind-map/logs?limit=20");
+          if (!response.ok) {
+            throw new Error("Не удалось загрузить журнал");
+          }
+          const logs = await response.json();
+          renderLogs(logs);
+        } catch (error) {
+          console.error(error);
+        }
+      }
+
+      function renderLogs(logs) {
+        if (!Array.isArray(logs)) return;
+        logList.innerHTML = "";
+        logs.forEach((log) => {
+          const li = document.createElement("li");
+          li.className =
+            "rounded-lg border border-slate-800 bg-slate-950/50 p-3 transition hover:border-sky-700/40";
+          li.innerHTML = `
+            <div class="flex items-center justify-between text-xs uppercase tracking-wider">
+              <span class="font-semibold text-sky-400">${log.level}</span>
+              <time class="text-slate-500">${new Date(log.created_at).toLocaleString()}</time>
+            </div>
+            <p class="mt-2 text-slate-200">${log.message}</p>
+            ${log.metadata ? `<pre class="mt-2 overflow-x-auto rounded bg-slate-900/80 p-2 text-xs text-slate-400">${JSON.stringify(log.metadata, null, 2)}</pre>` : ""}
+          `;
+          logList.appendChild(li);
+        });
+      }
+
+      refreshMindMap();
+      setInterval(() => {
+        refreshMindMap();
+        refreshLogs();
+      }, 8000);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a FastAPI application that persists mind map nodes, edges, and logs in PostgreSQL with the pgvector extension
- implement SQLAlchemy models, CRUD helpers, and Pydantic schemas plus a Tailwind/vis-network UI served directly by FastAPI
- document how to run the backend and list the Python dependencies for the service

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68fa236d53188324a8dde1794d6cb97e